### PR TITLE
2022-02-28 reorganize build workflows a bit

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -106,23 +106,11 @@ jobs:
           name: dtool-lookup-gui-linux
           path: /tmp/linux-build
 
-      - name: Download Linux build system description
-        uses: actions/download-artifact@v2
-        with:
-          name: linux-build-system-description
-          path: /tmp/linux-build-system-description
-
       - name: Download Windows build
         uses: actions/download-artifact@v2
         with:
           name: dtool-lookup-gui-windows
           path: /tmp/windows-build
-
-      - name: Download Windows build system description
-        uses: actions/download-artifact@v2
-        with:
-          name: windows-build-system-description
-          path: /tmp/windows-build-system-description
 
       - name: Download MacOS build
         uses: actions/download-artifact@v2
@@ -130,31 +118,32 @@ jobs:
           name: dtool-lookup-gui-macos
           path: /tmp/macos-build
 
-      - name: Download MacOS build system description
-        uses: actions/download-artifact@v2
-        with:
-          name: macos-build-system-description
-          path: /tmp/macos-build-system-description
-
-      - name: Package additional files with the bindaries
+      - name: Package additional files with the binaries
         run: |
+
           prefix=$(pwd)
           bash ${prefix}/maintenance/copy_files_into_folders.sh maintenance/files_to_include_in_release.txt /tmp/linux-build /tmp/macos-build /tmp/windows-build
-          cd /tmp/linux-build-system-description && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/linux-build
-          cd /tmp/macos-build-system-description && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/macos-build
-          cd /tmp/windows-build-system-description && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/windows-build
+          cd /tmp/linux-build \
+            && unzip dtool-lookup-gui*.zip \
+            && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/linux-release
+          cd /tmp/macos-build \
+            && unzip dtool-lookup-gui*.zip \
+            && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/macos-release
+          cd /tmp/windows-build \
+            && unzip dtool-lookup-gui*.zip \
+            && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/windows-release
 
-      - name: List content of builds
+      - name: List content of release
         run: |
-          ls -lhv /tmp/linux-build/
-          ls -lhv /tmp/windows-build/
-          ls -lhv /tmp/macos-build/
+          ls -lhv /tmp/linux-release/
+          ls -lhv /tmp/windows-release/
+          ls -lhv /tmp/macos-release/
 
       - name: Pack release assets
         run: |
-          cd /tmp/linux-build && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.zip ./*
-          cd /tmp/macos-build && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-macos.zip ./*
-          cd /tmp/windows-build && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-windows.zip ./*
+          cd /tmp/linux-release && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.zip ./*
+          cd /tmp/macos-release && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-macos.zip ./*
+          cd /tmp/windows-release && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-windows.zip ./*
 
       - name: Get master HEAD SHA
         id: get_master_sha
@@ -172,7 +161,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            /tmp/linux-build/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.zip
-            /tmp/macos-build/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-macos.zip
-            /tmp/windows-build/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-windows.zip
+            /tmp/linux-release/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.zip
+            /tmp/macos-release/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-macos.zip
+            /tmp/windows-release/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-windows.zip
           draft: true

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -99,6 +99,7 @@ jobs:
         run: |
           mkdir -p /tmp/linux-build
           mkdir -p /tmp/windows-build
+          mkdir -p /tmp/macos-build
 
       - name: Download Linux build
         uses: actions/download-artifact@v2
@@ -117,6 +118,12 @@ jobs:
         with:
           name: dtool-lookup-gui-macos
           path: /tmp/macos-build
+
+      - name: Unpack tar archives
+        run: |
+          cd /tmp/linux-build && tar -xvf dtool-lookup-gui-linux.tar
+          cd /tmp/macos-build && tar -xvf dtool-lookup-gui-macos.tar
+          cd /tmp/windows-build && tar -xvf dtool-lookup-gui-windows.tar
 
       - name: Package additional files with the binaries
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Pack release assets
         run: |
-          cd /tmp/linux-release && tar -cvzf -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.tar.gz ./*
+          cd /tmp/linux-release && tar -cvzf dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.tar.gz ./*
           cd /tmp/macos-release && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-macos.zip ./*
           cd /tmp/windows-release && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-windows.zip ./*
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -124,13 +124,10 @@ jobs:
           prefix=$(pwd)
           bash ${prefix}/maintenance/copy_files_into_folders.sh maintenance/files_to_include_in_release.txt /tmp/linux-build /tmp/macos-build /tmp/windows-build
           cd /tmp/linux-build \
-            && unzip dtool-lookup-gui*.zip \
             && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/linux-release
           cd /tmp/macos-build \
-            && unzip dtool-lookup-gui*.zip \
             && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/macos-release
           cd /tmp/windows-build \
-            && unzip dtool-lookup-gui*.zip \
             && bash ${prefix}/maintenance/copy_files_into_folders.sh files_to_include_in_release.txt /tmp/windows-release
 
       - name: List content of release
@@ -141,7 +138,7 @@ jobs:
 
       - name: Pack release assets
         run: |
-          cd /tmp/linux-release && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.zip ./*
+          cd /tmp/linux-release && tar -cvzf -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.tar.gz ./*
           cd /tmp/macos-release && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-macos.zip ./*
           cd /tmp/windows-release && zip -r dtool-lookup-gui-${{ steps.get_version.outputs.version }}-windows.zip ./*
 
@@ -161,7 +158,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            /tmp/linux-release/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.zip
+            /tmp/linux-release/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-linux.tar.gz
             /tmp/macos-release/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-macos.zip
             /tmp/windows-release/dtool-lookup-gui-${{ steps.get_version.outputs.version }}-windows.zip
           draft: true

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   build-on-ubuntu:
-    uses: livMatS/dtool-lookup-gui/.github/workflows/build-on-ubuntu.yml@master
+    uses: livMatS/dtool-lookup-gui/.github/workflows/build-on-ubuntu.yml@2022-02-28-reorganize-build-workflows-a-bit
 
   build-on-windows:
-    uses: livMatS/dtool-lookup-gui/.github/workflows/build-on-windows.yml@master
+    uses: livMatS/dtool-lookup-gui/.github/workflows/build-on-windows.yml@2022-02-28-reorganize-build-workflows-a-bit
 
   build-on-macos:
-    uses: livMatS/dtool-lookup-gui/.github/workflows/build-on-macos.yml@master
+    uses: livMatS/dtool-lookup-gui/.github/workflows/build-on-macos.yml@2022-02-28-reorganize-build-workflows-a-bit
 
   publish-on-pypi:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -81,7 +81,7 @@ jobs:
           pyinstaller.log \
           build/dtool-lookup-gui-macos-one-file/*.toc \
           build/dtool-lookup-gui-macos-one-file/*.txt \
-          build/dtool-lookup-gui-macos-one-file/html.toc
+          build/dtool-lookup-gui-macos-one-file/*.html
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -66,27 +66,27 @@ jobs:
         source venv/bin/activate
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-macos-one-file.spec 2>&1 | tee pyinstaller.log
         chmod +x dist/dtool-lookup-gui
-        echo " dist/dtool-lookup-gui" >> files_to_include_in_release.txt
+        echo "dist/dtool-lookup-gui" >> files_to_include_in_release.txt
 
     - name: Pack assets
-      run: |
-        zip dtool-lookup-gui-macos.zip \
-          dist/dtool-lookup-gui \
-          files_to_include_in_release.txt \
-          sw_vers.txt \
-          uname_a.txt \
-          brew_list_versions.txt \
-          pip_freeze.txt \
-          pip_freeze_local.txt \
-          pyinstaller.log \
-          build/dtool-lookup-gui-macos-one-file/*.toc \
-          build/dtool-lookup-gui-macos-one-file/*.txt \
-          build/dtool-lookup-gui-macos-one-file/html.toc
-
+        run: |
+          tar -cvf dtool-lookup-gui-macos.tar \
+            dist/dtool-lookup-gui \
+            files_to_include_in_release.txt \
+            sw_vers.txt \
+            uname_a.txt \
+            brew_list_versions.txt \
+            pip_freeze.txt \
+            pip_freeze_local.txt \
+            pyinstaller.log \
+            build/dtool-lookup-gui-macos-one-file/*.toc \
+            build/dtool-lookup-gui-macos-one-file/*.txt \
+            build/dtool-lookup-gui-macos-one-file/html.toc
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: dtool-lookup-gui-macos
-        path: dtool-lookup-gui-macos.zip
+        path: dtool-lookup-gui-macos.tar
+
         if-no-files-found: error

--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -69,19 +69,19 @@ jobs:
         echo "dist/dtool-lookup-gui" >> files_to_include_in_release.txt
 
     - name: Pack assets
-        run: |
-          tar -cvf dtool-lookup-gui-macos.tar \
-            dist/dtool-lookup-gui \
-            files_to_include_in_release.txt \
-            sw_vers.txt \
-            uname_a.txt \
-            brew_list_versions.txt \
-            pip_freeze.txt \
-            pip_freeze_local.txt \
-            pyinstaller.log \
-            build/dtool-lookup-gui-macos-one-file/*.toc \
-            build/dtool-lookup-gui-macos-one-file/*.txt \
-            build/dtool-lookup-gui-macos-one-file/html.toc
+      run: |
+        tar -cvf dtool-lookup-gui-macos.tar \
+          dist/dtool-lookup-gui \
+          files_to_include_in_release.txt \
+          sw_vers.txt \
+          uname_a.txt \
+          brew_list_versions.txt \
+          pip_freeze.txt \
+          pip_freeze_local.txt \
+          pyinstaller.log \
+          build/dtool-lookup-gui-macos-one-file/*.toc \
+          build/dtool-lookup-gui-macos-one-file/*.txt \
+          build/dtool-lookup-gui-macos-one-file/html.toc
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -66,25 +66,25 @@ jobs:
         source venv/bin/activate
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-macos-one-file.spec
 
+    - name: Pack assets
+        run: |
+          zip dtool-lookup-gui-macos.zip \
+            dist/dtool-lookup-gui \
+            files_to_include_in_release.txt \
+            sw_vers.txt \
+            uname_a.txt \
+            brew_list_versions.txt \
+            pip_freeze.txt \
+            pip_freeze_local.txt \
+            pyinstaller.log \
+            build/dtool-lookup-gui-macos-one-file/*.toc \
+            build/dtool-lookup-gui-macos-one-file/*.txt \
+            build/dtool-lookup-gui-macos-one-file/html.toc
+
+
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: dtool-lookup-gui-macos
-        path: dist/dtool-lookup-gui
+        path: dtool-lookup-gui-macos.zip
         if-no-files-found: error
-
-    - name: Upload build system description artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: macos-build-system-description
-        path: |
-          files_to_include_in_release.txt
-          sw_vers.txt
-          uname_a.txt
-          brew_list_versions.txt
-          pip_freeze.txt
-          pip_freeze_local.txt
-          pyinstaller.log
-          build/dtool-lookup-gui-macos-one-file/*.toc
-          build/dtool-lookup-gui-macos-one-file/*.txt
-          build/dtool-lookup-gui-macos-one-file/html.toc

--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -65,6 +65,7 @@ jobs:
       run: |
         source venv/bin/activate
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-macos-one-file.spec 2>&1 | tee pyinstaller.log
+        chmod +x dist/dtool-lookup-gui
         echo " dist/dtool-lookup-gui" >> files_to_include_in_release.txt
 
     - name: Pack assets

--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -65,13 +65,14 @@ jobs:
       run: |
         source venv/bin/activate
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-macos-one-file.spec 2>&1 | tee pyinstaller.log
-        chmod +x dist/dtool-lookup-gui
-        echo "dist/dtool-lookup-gui" >> files_to_include_in_release.txt
+        mv dist/dtool-lookup-gui dtool-lookup-gui
+        chmod +x dtool-lookup-gui
+        echo "dtool-lookup-gui" >> files_to_include_in_release.txt
 
     - name: Pack assets
       run: |
         tar -cvf dtool-lookup-gui-macos.tar \
-          dist/dtool-lookup-gui \
+          dtool-lookup-gui \
           files_to_include_in_release.txt \
           sw_vers.txt \
           uname_a.txt \

--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Package executable with pyinstaller
       run: |
         source venv/bin/activate
-        pyinstaller -y ./pyinstaller/dtool-lookup-gui-macos-one-file.spec
+        pyinstaller -y ./pyinstaller/dtool-lookup-gui-macos-one-file.spec 2>&1 | tee pyinstaller.log
         echo " dist/dtool-lookup-gui" >> files_to_include_in_release.txt
 
     - name: Pack assets

--- a/.github/workflows/build-on-macos.yml
+++ b/.github/workflows/build-on-macos.yml
@@ -65,21 +65,22 @@ jobs:
       run: |
         source venv/bin/activate
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-macos-one-file.spec
+        echo " dist/dtool-lookup-gui" >> files_to_include_in_release.txt
 
     - name: Pack assets
-        run: |
-          zip dtool-lookup-gui-macos.zip \
-            dist/dtool-lookup-gui \
-            files_to_include_in_release.txt \
-            sw_vers.txt \
-            uname_a.txt \
-            brew_list_versions.txt \
-            pip_freeze.txt \
-            pip_freeze_local.txt \
-            pyinstaller.log \
-            build/dtool-lookup-gui-macos-one-file/*.toc \
-            build/dtool-lookup-gui-macos-one-file/*.txt \
-            build/dtool-lookup-gui-macos-one-file/html.toc
+      run: |
+        zip dtool-lookup-gui-macos.zip \
+          dist/dtool-lookup-gui \
+          files_to_include_in_release.txt \
+          sw_vers.txt \
+          uname_a.txt \
+          brew_list_versions.txt \
+          pip_freeze.txt \
+          pip_freeze_local.txt \
+          pyinstaller.log \
+          build/dtool-lookup-gui-macos-one-file/*.toc \
+          build/dtool-lookup-gui-macos-one-file/*.txt \
+          build/dtool-lookup-gui-macos-one-file/html.toc
 
 
     - name: Upload artifact

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -68,20 +68,21 @@ jobs:
     - name: Package executable with pyinstaller
       run: |
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-linux-one-file.spec
+        echo " dist/dtool-lookup-gui" >> files_to_include_in_release.txt
 
     - name: Pack assets
-        run: |
-          zip dtool-lookup-gui-macos.zip \
-            dist/dtool-lookup-gui \
-            files_to_include_in_release.txt \
-            lsb_release_a.txt \
-            uname_a.txt \
-            apt_list_installed.txt \
-            pip_freeze.txt \
-            pyinstaller.log \
-            build/dtool-lookup-gui-linux-one-file/*.toc \
-            build/dtool-lookup-gui-linux-one-file/*.txt \
-            build/dtool-lookup-gui-linux-one-file/html.toc
+      run: |
+        zip dtool-lookup-gui-macos.zip \
+          dist/dtool-lookup-gui \
+          files_to_include_in_release.txt \
+          lsb_release_a.txt \
+          uname_a.txt \
+          apt_list_installed.txt \
+          pip_freeze.txt \
+          pyinstaller.log \
+          build/dtool-lookup-gui-linux-one-file/*.toc \
+          build/dtool-lookup-gui-linux-one-file/*.txt \
+          build/dtool-lookup-gui-linux-one-file/html.toc
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -30,6 +30,7 @@ jobs:
           pkg-config \
           python3-dev \
           gir1.2-gtk-3.0 \
+          gir1.2-gtksource-4 \
           libgtksourceview-4-0
 
     - name: Log system package info

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -85,7 +85,7 @@ jobs:
           pyinstaller.log \
           build/dtool-lookup-gui-linux-one-file/*.toc \
           build/dtool-lookup-gui-linux-one-file/*.txt \
-          build/dtool-lookup-gui-linux-one-file/html.toc
+          build/dtool-lookup-gui-linux-one-file/*.html
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -69,11 +69,13 @@ jobs:
     - name: Package executable with pyinstaller
       run: |
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-linux-one-file.spec 2>&1 | tee pyinstaller.log
-        echo " dist/dtool-lookup-gui" >> files_to_include_in_release.txt
+        chmod +x dist/dtool-lookup-gui
+        echo "dist/dtool-lookup-gui" >> files_to_include_in_release.txt
 
+    # use tar here, see https://github.com/actions/upload-artifact/issues/38
     - name: Pack assets
       run: |
-        zip dtool-lookup-gui-linux.zip \
+        tar -cvf dtool-lookup-gui-linux.tar \
           dist/dtool-lookup-gui \
           files_to_include_in_release.txt \
           lsb_release_a.txt \
@@ -89,5 +91,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: dtool-lookup-gui-linux
-        path: dtool-lookup-gui-linux.zip
+        path: dtool-lookup-gui-linux.tar
         if-no-files-found: error

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -69,24 +69,23 @@ jobs:
       run: |
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-linux-one-file.spec
 
+    - name: Pack assets
+        run: |
+          zip dtool-lookup-gui-macos.zip \
+            dist/dtool-lookup-gui \
+            files_to_include_in_release.txt \
+            lsb_release_a.txt \
+            uname_a.txt \
+            apt_list_installed.txt \
+            pip_freeze.txt \
+            pyinstaller.log \
+            build/dtool-lookup-gui-linux-one-file/*.toc \
+            build/dtool-lookup-gui-linux-one-file/*.txt \
+            build/dtool-lookup-gui-linux-one-file/html.toc
+
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: dtool-lookup-gui-linux
-        path: dist/dtool-lookup-gui
+        path: dtool-lookup-gui-linux.zip
         if-no-files-found: error
-
-    - name: Upload build system description artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: linux-build-system-description
-        path: |
-          files_to_include_in_release.txt
-          lsb_release_a.txt
-          uname_a.txt
-          apt_list_installed.txt
-          pip_freeze.txt
-          pyinstaller.log
-          build/dtool-lookup-gui-linux-one-file/*.toc
-          build/dtool-lookup-gui-linux-one-file/*.txt
-          build/dtool-lookup-gui-linux-one-file/html.toc

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -67,12 +67,12 @@ jobs:
 
     - name: Package executable with pyinstaller
       run: |
-        pyinstaller -y ./pyinstaller/dtool-lookup-gui-linux-one-file.spec
+        pyinstaller -y ./pyinstaller/dtool-lookup-gui-linux-one-file.spec 2>&1 | tee pyinstaller.log
         echo " dist/dtool-lookup-gui" >> files_to_include_in_release.txt
 
     - name: Pack assets
       run: |
-        zip dtool-lookup-gui-macos.zip \
+        zip dtool-lookup-gui-linux.zip \
           dist/dtool-lookup-gui \
           files_to_include_in_release.txt \
           lsb_release_a.txt \

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -69,14 +69,15 @@ jobs:
     - name: Package executable with pyinstaller
       run: |
         pyinstaller -y ./pyinstaller/dtool-lookup-gui-linux-one-file.spec 2>&1 | tee pyinstaller.log
-        chmod +x dist/dtool-lookup-gui
-        echo "dist/dtool-lookup-gui" >> files_to_include_in_release.txt
+        mv dist/dtool-lookup-gui dtool-lookup-gui
+        chmod +x dtool-lookup-gui
+        echo "dtool-lookup-gui" >> files_to_include_in_release.txt
 
     # use tar here, see https://github.com/actions/upload-artifact/issues/38
     - name: Pack assets
       run: |
         tar -cvf dtool-lookup-gui-linux.tar \
-          dist/dtool-lookup-gui \
+          dtool-lookup-gui \
           files_to_include_in_release.txt \
           lsb_release_a.txt \
           uname_a.txt \

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -28,6 +28,7 @@ jobs:
           base-devel
           curl
           git
+          zip
           mingw-w64-x86_64-cython
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-gtk3

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -127,7 +127,7 @@ jobs:
 
     - name: Pack assets
       run: |
-        zip dtool-lookup-gui-windows.zip \
+        tar -cvf dtool-lookup-gui-windows.tar \
           dist/dtool-lookup-gui.exe \
           files_to_include_in_release.txt \
           pacman_Q.txt \
@@ -146,6 +146,6 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: dtool-lookup-gui-windows
-        path: dtool-lookup-gui-windows.zip
+        path: dtool-lookup-gui-windows.tar
         if-no-files-found: error
 

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -123,12 +123,13 @@ jobs:
         # only ran into problems when calling PyInstaller or pyinstaller directly,
         # would never find package metadata within the venv, call as module mitigates the issue:
         python -m PyInstaller -y ./pyinstaller/dtool-lookup-gui-windows-one-file.spec 2>&1 | tee pyinstaller.log
-        echo " dist/dtool-lookup-gui.exe" >> files_to_include_in_release.txt
+        mv dist/dtool-lookup-gui.exe dtool-lookup-gui.exe
+        echo "dtool-lookup-gui.exe" >> files_to_include_in_release.txt
 
     - name: Pack assets
       run: |
         tar -cvf dtool-lookup-gui-windows.tar \
-          dist/dtool-lookup-gui.exe \
+          dtool-lookup-gui.exe \
           files_to_include_in_release.txt \
           pacman_Q.txt \
           diff_pacman_q.txt \

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -122,23 +122,24 @@ jobs:
         # only ran into problems when calling PyInstaller or pyinstaller directly,
         # would never find package metadata within the venv, call as module mitigates the issue:
         python -m PyInstaller -y ./pyinstaller/dtool-lookup-gui-windows-one-file.spec 2>&1 | tee pyinstaller.log
+        echo " dist/dtool-lookup-gui.exe" >> files_to_include_in_release.txt
 
     - name: Pack assets
-        run: |
-          zip dtool-lookup-gui-windows.zip \
-            dist/dtool-lookup-gui.exe \
-            files_to_include_in_release.txt
-            pacman_Q.txt \
-            diff_pacman_q.txt \
-            pip_freeze.txt \
-            diff_pip_freeze.txt \
-            pip_freeze_local.txt \
-            diff_pip_freeze_local.txt \
-            openssl_dlls.txt \
-            pyinstaller.log \
-            build/dtool-lookup-gui-windows-one-file/*.toc \
-            build/dtool-lookup-gui-windows-one-file/*.txt \
-            build/dtool-lookup-gui-windows-one-file/html.toc
+      run: |
+        zip dtool-lookup-gui-windows.zip \
+          dist/dtool-lookup-gui.exe \
+          files_to_include_in_release.txt \
+          pacman_Q.txt \
+          diff_pacman_q.txt \
+          pip_freeze.txt \
+          diff_pip_freeze.txt \
+          pip_freeze_local.txt \
+          diff_pip_freeze_local.txt \
+          openssl_dlls.txt \
+          pyinstaller.log \
+          build/dtool-lookup-gui-windows-one-file/*.toc \
+          build/dtool-lookup-gui-windows-one-file/*.txt \
+          build/dtool-lookup-gui-windows-one-file/html.toc
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -140,7 +140,7 @@ jobs:
           pyinstaller.log \
           build/dtool-lookup-gui-windows-one-file/*.toc \
           build/dtool-lookup-gui-windows-one-file/*.txt \
-          build/dtool-lookup-gui-windows-one-file/html.toc
+          build/dtool-lookup-gui-windows-one-file/*.html
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -123,27 +123,27 @@ jobs:
         # would never find package metadata within the venv, call as module mitigates the issue:
         python -m PyInstaller -y ./pyinstaller/dtool-lookup-gui-windows-one-file.spec 2>&1 | tee pyinstaller.log
 
-    - name: Upload executable artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: dtool-lookup-gui-windows
-        path: dist/dtool-lookup-gui.exe
-        if-no-files-found: error
+    - name: Pack assets
+        run: |
+          zip dtool-lookup-gui-windows.zip \
+            dist/dtool-lookup-gui.exe \
+            files_to_include_in_release.txt
+            pacman_Q.txt \
+            diff_pacman_q.txt \
+            pip_freeze.txt \
+            diff_pip_freeze.txt \
+            pip_freeze_local.txt \
+            diff_pip_freeze_local.txt \
+            openssl_dlls.txt \
+            pyinstaller.log \
+            build/dtool-lookup-gui-windows-one-file/*.toc \
+            build/dtool-lookup-gui-windows-one-file/*.txt \
+            build/dtool-lookup-gui-windows-one-file/html.toc
 
-    - name: Upload build system description artifact
+    - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
         name: windows-build-system-description
-        path: |
-          files_to_include_in_release.txt
-          pacman_Q.txt
-          diff_pacman_q.txt
-          pip_freeze.txt
-          diff_pip_freeze.txt
-          pip_freeze_local.txt
-          diff_pip_freeze_local.txt
-          openssl_dlls.txt
-          pyinstaller.log
-          build/dtool-lookup-gui-windows-one-file/*.toc
-          build/dtool-lookup-gui-windows-one-file/*.txt
-          build/dtool-lookup-gui-windows-one-file/html.toc
+        path: dtool-lookup-gui-windows.zip
+        if-no-files-found: error
+

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -145,7 +145,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        name: windows-build-system-description
+        name: dtool-lookup-gui-windows
         path: dtool-lookup-gui-windows.zip
         if-no-files-found: error
 

--- a/maintenance/copy_files_into_folders.sh
+++ b/maintenance/copy_files_into_folders.sh
@@ -7,6 +7,7 @@ shift
 
 for target_folder in "$@"
 do
+    mkdir -p "$target_folder"
     echo xargs -a "$file_list" cp -t "$target_folder"
     xargs -a "$file_list" cp -t "$target_folder"
 done


### PR DESCRIPTION
Main purpose here is to preserve the executable bit for MacOS and Linux relase binaries, file permissions are broken by github actions zipping, https://github.com/actions/upload-artifact/issues/38.

Also condensed workflows a bit.

Also added missing system dependency in Ubuntu workflow, https://github.com/livMatS/dtool-lookup-gui/pull/94/commits/dd75f126d19f0a2dae234493f9b54b198eb64afc, thanks to a hint by Tarek.