### PR TITLE
preserve non-ASCII characters in README.yml content queried from lookup server

### DIFF
--- a/dtool_lookup_gui/models/datasets.py
+++ b/dtool_lookup_gui/models/datasets.py
@@ -274,7 +274,7 @@ class DatasetModel:
 
     @classmethod
     async def query(cls, query_text):
-        datasets = await async_dl.by_query(query_text)
+        datasets = await async_dl.query(query_text)
         return [await cls.from_lookup(lookup_dict) for lookup_dict in datasets]
 
     @classmethod

--- a/dtool_lookup_gui/models/datasets.py
+++ b/dtool_lookup_gui/models/datasets.py
@@ -35,8 +35,9 @@ from dtoolcore.utils import generous_parse_uri
 from dtool_info.utils import date_fmt, sizeof_fmt
 
 from dtool_info.inventory import _dataset_info
-from dtool_lookup_api.core.LookupClient import ConfigurationBasedLookupClient
+import dtool_lookup_api.asynchronous as async_dl
 
+from ..utils.logging import _log_nested
 from ..utils.multiprocessing import StatusReportingChildProcessBuilder, process_initializer
 from ..utils.progressbar import ProgressBar
 
@@ -268,24 +269,18 @@ class DatasetModel:
 
     @classmethod
     async def search(cls, keyword):
-        async with ConfigurationBasedLookupClient() as lookup:
-            datasets = await lookup.search(keyword)
-
+        datasets = await async_dl.search(keyword)
         return [await cls.from_lookup(lookup_dict) for lookup_dict in datasets]
 
     @classmethod
     async def query(cls, query_text):
-        async with ConfigurationBasedLookupClient() as lookup:
-            datasets = await lookup.by_query(query_text)
-
+        datasets = await async_dl.by_query(query_text)
         return [await cls.from_lookup(lookup_dict) for lookup_dict in datasets]
 
     @classmethod
     async def query_all(cls):
         """Query all datasets from lookup server."""
-        async with ConfigurationBasedLookupClient() as lookup:
-            datasets = await lookup.all()
-
+        datasets = await async_dl.all()
         return [await cls.from_lookup(lookup_dict) for lookup_dict in datasets]
 
     def __str__(self):
@@ -334,10 +329,12 @@ class DatasetModel:
 
     async def get_readme(self):
         if 'readme_content' in self._dataset_info:
+            logger.debug("README.yml cached.")
             return self._dataset_info['readme_content']
-        async with ConfigurationBasedLookupClient() as lookup:
-            readme_dict = await lookup.readme(self.uri)
-        self._dataset_info['readme_content'] = yaml.dump(readme_dict)
+
+        logger.debug("README.yml queried from lookup server.")
+        readme_dict = await async_dl.readme(self.uri)
+        self._dataset_info['readme_content'] = yaml.dump(readme_dict, allow_unicode=True)
         return self._dataset_info['readme_content']
 
     async def get_manifest(self):
@@ -346,8 +343,7 @@ class DatasetModel:
             return dict()
         if 'manifest' in self._dataset_info:
             return self._dataset_info['manifest']
-        async with ConfigurationBasedLookupClient() as lookup:
-            manifest_dict = await lookup.manifest(self.uri)
+        manifest_dict = await async_dl.manifest(self.uri)
         self._dataset_info['manifest'] = _mangle_lookup_manifest(manifest_dict)
         return self._dataset_info['manifest']
 

--- a/dtool_lookup_gui/utils/logging.py
+++ b/dtool_lookup_gui/utils/logging.py
@@ -39,7 +39,7 @@ DEFAULT_LABEL_MAX_LINES = 1
 
 
 def _log_nested(log_func, dct):
-    for l in json.dumps(dct, indent=2, default=str).splitlines():
+    for l in json.dumps(dct, indent=2, default=str, ensure_ascii=False).splitlines():
         log_func(l)
 
 # filters


### PR DESCRIPTION
I will never figure out this encoding/decoding business. With the README content received from the lookup server, this `allow_unicode` flag in `yaml.dump` (and the `ensure_ascii=False` flag for `json.dumps`) is necessary, with the local README template https://github.com/livMatS/dtool-lookup-gui/blob/5a64afec124f26a97ee23014eba6ef62f9cca1f2/dtool_lookup_gui/models/base_uris.py#L147-L150 everything works fine without its...

Also removed `ConfigurationBasedLookupClient` from `datasets.py` and replaced it by the documented external API calls from https://github.com/livMatS/dtool-lookup-api, would like to "phase out" the use of `ConfigurationBasedLookupClient` and align the `dtool_lookup_api` with the REST API of the server once that has been documented.