### PR TITLE
refactoring authenication as main app action

### DIFF
--- a/dtool_lookup_gui/main.py
+++ b/dtool_lookup_gui/main.py
@@ -225,6 +225,11 @@ class Application(Gtk.Application):
         export_config_action.connect("activate", self.do_export_config)
         self.add_action(export_config_action)
 
+        # renew-token action
+        renew_token_action = Gio.SimpleAction.new("renew-token", string_variant.get_type())
+        renew_token_action.connect("activate", self.do_renew_token)
+        self.add_action(renew_token_action)
+
         Gtk.Application.do_startup(self)
 
     # custom application-scoped actions
@@ -307,6 +312,35 @@ class Application(Gtk.Application):
         """Doesn't do anything, just documents how GTK calls this method
            first when emitting dtool-config-changed signal."""
         logger.debug("method handler for 'dtool-config-changed' called.")
+
+    def do_renew_token(self, action, value):
+        """Request new token."""
+        password = value.get_string()
+
+        # get username somewhere
+
+        # logger.debug(f"Export config to '{config_file}':")
+        config = dtoolcore.utils._get_config_dict_from_file()
+
+        from dtool_lookup_api.core.LookupClient import authenticate
+
+        async def retrieve_token(auth_url, username, password):
+            try:
+                token = await authenticate(auth_url, username, password)
+            except Exception as e:
+                logger.error(str(e))
+                return
+
+            self.token_entry.set_text(token) # store token somewhere
+
+        # def authenticate(username, password):
+        # await
+        asyncio.create_task(retrieve_token(
+            self.authenticator_url_entry.get_text(),
+            username,
+            password))
+
+        self.emit('dtool-token-changed')
 
 
 def run_gui():

--- a/dtool_lookup_gui/views/settings_dialog.py
+++ b/dtool_lookup_gui/views/settings_dialog.py
@@ -205,16 +205,11 @@ class SettingsDialog(Gtk.Window):
 
     @Gtk.Template.Callback()
     def on_renew_token_clicked(self, widget):
-        def authenticate(username, password):
-            asyncio.create_task(self.retrieve_token(
-                self.authenticator_url_entry.get_text(),
-                username,
-                password))
 
-            # Reconnect since settings may have been changed
-            #asyncio.create_task(self.main_application.lookup_tab.connect())
+        # show authentication dialoogue and get username and password
 
-        AuthenticationDialog(authenticate, Config.username, Config.password).show()
+        # TODO: check howto pass two strings
+        self.get_action_group("app").activate_action('renew-token', GLib.Variant.new_string(password))
 
     @Gtk.Template.Callback()
     def on_reset_config_clicked(self, widget):
@@ -276,14 +271,15 @@ class SettingsDialog(Gtk.Window):
         settings.item_download_directory = item_download_directory
 
     async def retrieve_token(self, auth_url, username, password):
-        #self.main_application.error_bar.hide()
+        # self.main_application.error_bar.hide()
         try:
             token = await authenticate(auth_url, username, password)
         except Exception as e:
             logger.error(str(e))
             return
-        #self.builder.get_object('token-entry').set_text(token)
+        # self.builder.get_object('token-entry').set_text(token)
         self.token_entry.set_text(token)
+
         await self._refresh_list_of_endpoints()
 
     _configuration_dialogs = {


### PR DESCRIPTION
We should implement authentication as a GTK action, see e.g. https://docs.gtk.org/gtk4/actions.html,

https://lazka.github.io/pgi-docs/Gtk-3.0/classes/Action.html
https://lazka.github.io/pgi-docs/Gio-2.0/classes/Action.html#Gio.Action