### PR TITLE
MAINT: treat README as text

### DIFF
--- a/dtool_lookup_gui/models/datasets.py
+++ b/dtool_lookup_gui/models/datasets.py
@@ -337,8 +337,7 @@ class DatasetModel:
 
         logger.debug("README.yml queried from lookup server.")
         async with ConfigurationBasedLookupClient() as lookup:
-            readme_dict = await lookup.readme(self.uri)
-        self._dataset_info['readme_content'] = yaml.dump(readme_dict, allow_unicode=True)
+            self._dataset_info['readme_content'] = await lookup.readme(self.uri)
         return self._dataset_info['readme_content']
 
     async def get_manifest(self):


### PR DESCRIPTION
This now treats README as plain text when returned from lookup api.
