### PR TITLE
BUG : save metadata button fixed

### DIFF
--- a/pyinstaller/hooks/hook-yamllint.py
+++ b/pyinstaller/hooks/hook-yamllint.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+# Collect yamllint's data files, which include the default configuration
+datas = collect_data_files('yamllint')


### PR DESCRIPTION
I have tested the save metadata button in the development and it works as intended , but it would seem that in the packaged application it does not work.

In my terminal i get an error stating "FileNotFoundError: [Errno 2] No such file or directory: 'default'"


the error is in the line 788 " conf = YamlLintConfig('extends: default')  # using the default config"  in main_window.py file in views

It seems likely that this issue arises because the packaging process did not include the default YAML configuration file. As a result, YAML linting fails, which in turn prevents the Save Metadata button from functioning.

The cause of the error can be further verified by disabling the yamllinting in the settings of the packaged application which will turn off the yaml linting hence the save metadata button will work properly again in the packaged application because yaml linting was turned off. 

So i tried to include the yaml files while packaging the application  by including a "hook-yamllint.py" file that contains the following code 

from PyInstaller.utils.hooks import collect_data_files
datas = collect_data_files('yamllint')

this seems to have fixed the issue with the save metadata button in the packaged application.