### PR TITLE
fix: bundle gdk-pixbuf pixbuf loaders to fix GTK image crash on Linux

### DIFF
--- a/pyinstaller/linux/dtool-lookup-gui-linux-one-file.spec
+++ b/pyinstaller/linux/dtool-lookup-gui-linux-one-file.spec
@@ -1,9 +1,63 @@
 # -*- mode: python ; coding: utf-8 -*-
 from glob import glob
 from PyInstaller.utils.hooks import collect_entry_point, copy_metadata
+import subprocess, glob as _glob
 
 root_dir = os.path.abspath(os.curdir)
 block_cipher = None
+
+# --- gdk-pixbuf loaders ---
+# Find the loaders directory
+_pixbuf_loaders_dir = None
+for _candidate in [
+    "/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders",
+    "/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders",
+]:
+    if os.path.isdir(_candidate):
+        _pixbuf_loaders_dir = _candidate
+        break
+
+# Fall back to pkg-config / environment query
+if _pixbuf_loaders_dir is None:
+    try:
+        _pixbuf_loaders_dir = subprocess.check_output(
+            ["pkg-config", "--variable=gdk_pixbuf_moduledir", "gdk-pixbuf-2.0"],
+            text=True
+        ).strip()
+    except Exception:
+        pass
+
+pixbuf_loaders_datas = []
+pixbuf_loaders_cache = []
+if _pixbuf_loaders_dir and os.path.isdir(_pixbuf_loaders_dir):
+    # Include all .so loader files
+    pixbuf_loaders_datas = [
+        (so, "gdk_pixbuf_loaders")
+        for so in _glob.glob(os.path.join(_pixbuf_loaders_dir, "*.so"))
+    ]
+    # Generate loaders.cache pointing to bundled paths
+    _cache_content_lines = []
+    try:
+        raw = subprocess.check_output(
+            ["gdk-pixbuf-query-loaders"] + [so for so, _ in pixbuf_loaders_datas],
+            text=True
+        )
+        # Rewrite absolute paths to relative bundle paths
+        for line in raw.splitlines():
+            if line.startswith('"') and _pixbuf_loaders_dir in line:
+                so_file = os.path.basename(line.strip().strip('"'))
+                line = f'"gdk_pixbuf_loaders/{so_file}"'
+            _cache_content_lines.append(line)
+    except Exception:
+        pass
+    if _cache_content_lines:
+        import tempfile
+        _cache_tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix="loaders.cache", delete=False
+        )
+        _cache_tmp.write("\n".join(_cache_content_lines) + "\n")
+        _cache_tmp.close()
+        pixbuf_loaders_cache = [(_cache_tmp.name, "gdk_pixbuf_loaders")]
 
 # storage brokers and their entrypoints need the following special treatment,
 # as they won't be discovered by pyinstaller's default tracing mechanisms
@@ -38,7 +92,8 @@ hooks_path = [os.path.join(root_dir, 'pyinstaller/hooks')]
 
 runtime_hooks = [
   os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py'),
-  os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_glib.py')
+  os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_glib.py'),
+  os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_gdk_pixbuf.py'),
 ]
 
 a = Analysis(
@@ -49,6 +104,8 @@ a = Analysis(
         *additional_datas,
         *dtool_storage_brokers_datas,
         *dtool_hidden_imports_datas,
+        *pixbuf_loaders_datas,
+        *pixbuf_loaders_cache,
     ],
     hiddenimports=[
       *dtool_hidden_imports,

--- a/pyinstaller/linux/dtool-lookup-gui-linux.spec
+++ b/pyinstaller/linux/dtool-lookup-gui-linux.spec
@@ -1,9 +1,63 @@
 # -*- mode: python ; coding: utf-8 -*-
 from glob import glob
 from PyInstaller.utils.hooks import collect_entry_point, copy_metadata
+import subprocess, glob as _glob
 
 root_dir = os.path.abspath(os.curdir)
 block_cipher = None
+
+# --- gdk-pixbuf loaders ---
+# Find the loaders directory
+_pixbuf_loaders_dir = None
+for _candidate in [
+    "/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders",
+    "/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders",
+]:
+    if os.path.isdir(_candidate):
+        _pixbuf_loaders_dir = _candidate
+        break
+
+# Fall back to pkg-config / environment query
+if _pixbuf_loaders_dir is None:
+    try:
+        _pixbuf_loaders_dir = subprocess.check_output(
+            ["pkg-config", "--variable=gdk_pixbuf_moduledir", "gdk-pixbuf-2.0"],
+            text=True
+        ).strip()
+    except Exception:
+        pass
+
+pixbuf_loaders_datas = []
+pixbuf_loaders_cache = []
+if _pixbuf_loaders_dir and os.path.isdir(_pixbuf_loaders_dir):
+    # Include all .so loader files
+    pixbuf_loaders_datas = [
+        (so, "gdk_pixbuf_loaders")
+        for so in _glob.glob(os.path.join(_pixbuf_loaders_dir, "*.so"))
+    ]
+    # Generate loaders.cache pointing to bundled paths
+    _cache_content_lines = []
+    try:
+        raw = subprocess.check_output(
+            ["gdk-pixbuf-query-loaders"] + [so for so, _ in pixbuf_loaders_datas],
+            text=True
+        )
+        # Rewrite absolute paths to relative bundle paths
+        for line in raw.splitlines():
+            if line.startswith('"') and _pixbuf_loaders_dir in line:
+                so_file = os.path.basename(line.strip().strip('"'))
+                line = f'"gdk_pixbuf_loaders/{so_file}"'
+            _cache_content_lines.append(line)
+    except Exception:
+        pass
+    if _cache_content_lines:
+        import tempfile
+        _cache_tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix="loaders.cache", delete=False
+        )
+        _cache_tmp.write("\n".join(_cache_content_lines) + "\n")
+        _cache_tmp.close()
+        pixbuf_loaders_cache = [(_cache_tmp.name, "gdk_pixbuf_loaders")]
 
 # storage brokers and their entrypoints need the following special treatment,
 # as they won't be discovered by pyinstaller's default tracing mechanisms
@@ -38,7 +92,8 @@ hooks_path = [os.path.join(root_dir, 'pyinstaller/hooks')]
 
 runtime_hooks = [
   os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_jinja2.py'),
-  os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_glib.py')
+  os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_glib.py'),
+  os.path.join(root_dir, 'pyinstaller/rthooks/pyi_rth_gdk_pixbuf.py'),
 ]
 
 a = Analysis(
@@ -49,6 +104,8 @@ a = Analysis(
         *additional_datas,
         *dtool_storage_brokers_datas,
         *dtool_hidden_imports_datas,
+        *pixbuf_loaders_datas,
+        *pixbuf_loaders_cache,
     ],
     hiddenimports=[
       *dtool_hidden_imports,

--- a/pyinstaller/rthooks/pyi_rth_gdk_pixbuf.py
+++ b/pyinstaller/rthooks/pyi_rth_gdk_pixbuf.py
@@ -1,0 +1,9 @@
+import os, sys
+
+loaders_dir = os.path.join(sys._MEIPASS, "gdk_pixbuf_loaders")
+cache_file = os.path.join(loaders_dir, "loaders.cache")
+
+if os.path.isdir(loaders_dir):
+    os.environ["GDK_PIXBUF_MODULEDIR"] = loaders_dir
+if os.path.isfile(cache_file):
+    os.environ["GDK_PIXBUF_MODULE_FILE"] = cache_file

--- a/pyinstaller/rthooks/pyi_rth_gdk_pixbuf.py
+++ b/pyinstaller/rthooks/pyi_rth_gdk_pixbuf.py
@@ -1,9 +1,45 @@
-import os, sys
+"""
+Runtime hook: fix gdk-pixbuf loaders path resolution inside PyInstaller bundle.
+
+The loaders.cache bundled at build time contains relative paths like:
+  "gdk_pixbuf_loaders/libpixbufloader-png.so"
+
+gdk-pixbuf requires absolute paths, so we rewrite the cache to a temp file
+with sys._MEIPASS-prefixed absolute paths, then point GDK_PIXBUF_MODULE_FILE
+at that temp file.
+
+This runs after PyInstaller's own pyi_rth_gdkpixbuf.py, overriding whatever
+it set (which would point to a non-existent path anyway).
+"""
+import os
+import sys
+import tempfile
 
 loaders_dir = os.path.join(sys._MEIPASS, "gdk_pixbuf_loaders")
-cache_file = os.path.join(loaders_dir, "loaders.cache")
+bundled_cache = os.path.join(loaders_dir, "loaders.cache")
 
 if os.path.isdir(loaders_dir):
     os.environ["GDK_PIXBUF_MODULEDIR"] = loaders_dir
-if os.path.isfile(cache_file):
-    os.environ["GDK_PIXBUF_MODULE_FILE"] = cache_file
+
+    if os.path.isfile(bundled_cache):
+        # Rewrite relative paths to absolute paths for this runtime instance.
+        # Build-time cache has lines like: "gdk_pixbuf_loaders/libpixbufloader-png.so"
+        # Runtime needs:                   "/tmp/_MEIxxxxxx/gdk_pixbuf_loaders/libpixbufloader-png.so"
+        with open(bundled_cache, "r") as f:
+            content = f.read()
+
+        content = content.replace(
+            '"gdk_pixbuf_loaders/',
+            '"' + loaders_dir + '/'
+        )
+
+        fd, tmp_cache = tempfile.mkstemp(suffix="_loaders.cache")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+            os.environ["GDK_PIXBUF_MODULE_FILE"] = tmp_cache
+        except Exception:
+            try:
+                os.unlink(tmp_cache)
+            except OSError:
+                pass


### PR DESCRIPTION
## Problem
The Linux smoke test crashes with exit 134 (SIGABRT) because the gdk-pixbuf 
pixbuf loaders (.so files) and loaders.cache are not included in the PyInstaller 
bundle. When GTK tries to load `image-missing.png` from its internal icon resources, 
it cannot find any PNG decoder and raises a fatal assertion error.

Error observed:
```
Could not load a pixbuf from /org/gtk/libgtk/icons/16x16/status/image-missing.png
Unrecognized image file format (gdk-pixbuf-error-quark, 3)
Gtk:ERROR: ensure_surface_for_gicon: assertion failed
```

## Fix
1. Both Linux `.spec` files now discover the system `gdk-pixbuf` loaders directory 
   at build time, bundle the `.so` loader files into `gdk_pixbuf_loaders/`, and 
   generate a `loaders.cache` with bundle-relative paths.
2. New runtime hook `pyi_rth_gdk_pixbuf.py` sets `GDK_PIXBUF_MODULE_FILE` and 
   `GDK_PIXBUF_MODULEDIR` to point at the bundled loaders when the app starts.

Fixes smoke test crash (exit 134 / SIGABRT) on Ubuntu 24.04 runners.