### PR TITLE
Resolve test xfails: implement README-tree rebuild (#526) and exercise base-URI listing timeout (#45)

### DIFF
--- a/dtool_lookup_gui/views/main_window.py
+++ b/dtool_lookup_gui/views/main_window.py
@@ -679,6 +679,21 @@ class MainWindow(Gtk.ApplicationWindow):
         self._rebuild_readme_tree(yaml_content)
         self.save_metadata_button.set_sensitive(False)
 
+    def _rebuild_readme_tree(self, yaml_content):
+        """Rebuild the README tree view from YAML text.
+
+        Used after saving metadata so the tree reflects the new content without
+        requiring the dataset to be re-selected. Mirrors the tree population done
+        when a dataset's README is loaded.
+        """
+        readme_dict = yaml.safe_load(yaml_content)
+
+        store = self.readme_tree_view.get_model()
+        store.clear()
+        fill_readme_tree_store(store, readme_dict)
+        self.readme_tree_view.columns_autosize()
+        self.readme_tree_view.show_all()
+
     def do_copy_dataset(self, action, value):
         """Copy a dataset from source_uri to destination_uri.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,6 +41,13 @@ import warnings
 # app registers locally with no export -- which is exactly how the busless CI runners behave.
 os.environ["DBUS_SESSION_BUS_ADDRESS"] = "/dev/null"
 
+# Use the in-memory GSettings backend. The default dconf backend needs the
+# session bus we just disabled (so writes fail with "dconf-WARNING ... does not
+# contain a colon" and don't persist -- e.g. registering a local base URI never
+# reaches base_uri_list_box). The memory backend gives each test process fresh,
+# fully isolated, working settings.
+os.environ["GSETTINGS_BACKEND"] = "memory"
+
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('GtkSource', '4')

--- a/test/test_main_window_action_refactors.py
+++ b/test/test_main_window_action_refactors.py
@@ -46,10 +46,6 @@ from dtool_lookup_gui.models.datasets import DatasetModel
 # save-metadata action
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(reason="do_save_metadata calls MainWindow._rebuild_readme_tree which "
-                          "does not exist; the readme tree is never rebuilt after save. "
-                          "See issue #526.",
-                   strict=False)
 @pytest.mark.asyncio
 async def test_do_save_metadata_valid_yaml(populated_app_with_local_dataset_data, local_dataset_uri):
     """save-metadata action with valid YAML saves readme and rebuilds tree."""
@@ -72,16 +68,15 @@ async def test_do_save_metadata_valid_yaml(populated_app_with_local_dataset_data
     new_yaml = "project: action-test\nauthor: Tester\nversion: 99\n"
 
     put_readme_calls = []
-    original_put_readme = rows[0].dataset.put_readme
-
-    def mock_put_readme(text):
-        put_readme_calls.append(text)
-
-    with patch.object(rows[0].dataset, 'put_readme', side_effect=mock_put_readme):
-        with patch('dtool_lookup_gui.models.settings.settings.yaml_linting_enabled', False):
+    # put_readme is a DatasetModel class method; patch at class level. Disable
+    # linting via PropertyMock (the property has no deleter). save-metadata
+    # dispatches synchronously, so assert without a settle-sleep that could let a
+    # background readme reload overwrite the tree.
+    with patch.object(DatasetModel, 'put_readme',
+                      side_effect=lambda t: put_readme_calls.append(t)):
+        with patch.object(Settings, 'yaml_linting_enabled',
+                          new_callable=PropertyMock, return_value=False):
             main_window.activate_action('save-metadata', GLib.Variant.new_string(new_yaml))
-
-    await asyncio.sleep(0.2)
 
     assert put_readme_calls, "put_readme() should have been called"
     assert put_readme_calls[0] == new_yaml

--- a/test/test_main_window_actions.py
+++ b/test/test_main_window_actions.py
@@ -774,11 +774,34 @@ async def test_do_select_dataset_row_by_uri_direct_call(populated_app_with_mock_
 # Tests for base URI listing timeout — fixes #45
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(reason="activate_action('refresh-view') alone does not select a base-URI row "
-                          "in this fixture, so the listing path (and its asyncio.wait_for timeout) "
-                          "is never reached and no timeout error is logged. Needs explicit "
-                          "base-URI row selection to exercise the #45 timeout feature.",
-                   strict=False)
+async def _add_local_base_uri_row(main_window, local_dataset_uri):
+    """Register the local dataset's base URI and return its DtoolBaseURIRow.
+
+    The base-URI listing path only runs for a real DtoolBaseURIRow, and the
+    isolated test config has none registered, so register one explicitly.
+    """
+    import os
+    import asyncio as _asyncio
+    from dtool_lookup_gui.models.base_uris import LocalBaseURIModel
+    from dtool_lookup_gui.widgets.base_uri_row import DtoolBaseURIRow
+
+    base_dir = os.path.dirname(local_dataset_uri)
+    try:
+        LocalBaseURIModel.add_directory(base_dir)
+    except ValueError:
+        pass  # already registered
+
+    main_window.activate_action("refresh-view")
+    start = time.time()
+    while time.time() - start < 10:
+        base_rows = [r for r in main_window.base_uri_list_box.get_children()
+                     if isinstance(r, DtoolBaseURIRow)]
+        if base_rows:
+            return base_rows[0]
+        await _asyncio.sleep(0.1)
+    return None
+
+
 @pytest.mark.asyncio
 async def test_base_uri_listing_timeout_shows_error(populated_app_with_local_dataset_data,
                                                      local_dataset_uri, caplog):
@@ -793,6 +816,9 @@ async def test_base_uri_listing_timeout_shows_error(populated_app_with_local_dat
     windows = populated_app_with_local_dataset_data.get_windows()
     main_window = [w for w in windows if isinstance(w, MainWindow)][0]
 
+    base_row = await _add_local_base_uri_row(main_window, local_dataset_uri)
+    assert base_row is not None, "Need a base-URI row to exercise listing"
+
     # Set a very short timeout so the test runs fast
     original_timeout = settings.base_uri_listing_timeout
     settings.base_uri_listing_timeout = 1  # 1 second
@@ -804,27 +830,22 @@ async def test_base_uri_listing_timeout_shows_error(populated_app_with_local_dat
     try:
         with patch(
             "dtool_lookup_gui.models.base_uris.BaseURI.all_datasets",
-            new=AsyncMock(side_effect=lambda: slow_all_datasets()),
+            new=AsyncMock(side_effect=slow_all_datasets),
         ):
             with caplog.at_level(logging.ERROR, logger="dtool_lookup_gui.views.main_window"):
-                main_window.activate_action("refresh-view")
-                # Wait long enough for timeout to fire (timeout=1s + some margin)
-                await _asyncio.sleep(2.5)
+                # Selecting the base-URI row triggers the listing path + its timeout.
+                main_window.activate_action(
+                    "show-base-uri", GLib.Variant.new_uint32(base_row.get_index()))
+                await _asyncio.sleep(2.5)  # > timeout, let it fire
 
-        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
-        assert error_records, "Expected a timeout error to be logged"
-        msg = error_records[-1].message
-        assert "timed out" in msg.lower() or "timeout" in msg.lower(), \
-            f"Expected timeout message, got: {msg!r}"
+        timeout_errors = [r for r in caplog.records
+                          if r.levelno >= logging.ERROR
+                          and ("timed out" in r.message.lower() or "timeout" in r.message.lower())]
+        assert timeout_errors, "Expected a timeout error to be logged"
     finally:
         settings.base_uri_listing_timeout = original_timeout
 
 
-@pytest.mark.xfail(reason="activate_action('refresh-view') alone does not select a base-URI row "
-                          "in this fixture, so BaseURI.all_datasets() is never reached and the "
-                          "patched listing never runs. Needs explicit base-URI row selection to "
-                          "exercise the timeout-disabled path; tracked with the #45 timeout work.",
-                   strict=False)
 @pytest.mark.asyncio
 async def test_base_uri_listing_no_timeout_when_disabled(populated_app_with_local_dataset_data,
                                                           local_dataset_uri, caplog):
@@ -837,6 +858,9 @@ async def test_base_uri_listing_no_timeout_when_disabled(populated_app_with_loca
     windows = populated_app_with_local_dataset_data.get_windows()
     main_window = [w for w in windows if isinstance(w, MainWindow)][0]
 
+    base_row = await _add_local_base_uri_row(main_window, local_dataset_uri)
+    assert base_row is not None, "Need a base-URI row to exercise listing"
+
     original_timeout = settings.base_uri_listing_timeout
     settings.base_uri_listing_timeout = 0  # disabled
 
@@ -848,14 +872,14 @@ async def test_base_uri_listing_no_timeout_when_disabled(populated_app_with_loca
         return []
 
     try:
-        # Pass the coroutine function directly so AsyncMock awaits it; a
-        # lambda returning slow_but_completes() would yield an un-awaited
-        # coroutine and the body would never run.
+        # Pass the coroutine function directly so AsyncMock awaits it; a lambda
+        # returning slow_but_completes() would yield an un-awaited coroutine.
         with patch(
             "dtool_lookup_gui.models.base_uris.BaseURI.all_datasets",
             new=AsyncMock(side_effect=slow_but_completes),
         ):
-            main_window.activate_action("refresh-view")
+            main_window.activate_action(
+                "show-base-uri", GLib.Variant.new_uint32(base_row.get_index()))
             await _asyncio.sleep(2.0)
 
         timeout_errors = [r for r in caplog.records
@@ -871,10 +895,6 @@ async def test_base_uri_listing_no_timeout_when_disabled(populated_app_with_loca
 # Tests for README tree rebuild after save — fixes #526
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(reason="do_save_metadata / on_save_metadata_button_clicked calls "
-                          "MainWindow._rebuild_readme_tree which does not exist, so the tree is "
-                          "never rebuilt after save. See issue #526.",
-                   strict=False)
 @pytest.mark.asyncio
 async def test_readme_tree_rebuilt_after_save(populated_app_with_local_dataset_data,
                                                local_dataset_uri):
@@ -883,9 +903,10 @@ async def test_readme_tree_rebuilt_after_save(populated_app_with_local_dataset_d
     """
     import asyncio as _asyncio
     import time
-    import yaml
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import patch, PropertyMock
     from dtool_lookup_gui.views.main_window import MainWindow
+    from dtool_lookup_gui.models.datasets import DatasetModel
+    from dtool_lookup_gui.models.settings import Settings
 
     windows = populated_app_with_local_dataset_data.get_windows()
     main_window = [w for w in windows if isinstance(w, MainWindow)][0]
@@ -905,16 +926,15 @@ async def test_readme_tree_rebuilt_after_save(populated_app_with_local_dataset_d
 
     new_readme = "project: test-project\nauthor: Test Author\nversion: 42\n"
 
-    # Patch put_readme so we don't write to disk
-    with patch.object(rows[0].dataset, "put_readme", return_value=None):
+    # put_readme is a DatasetModel class method (patch at class level); disable
+    # linting via PropertyMock. on_save_metadata_button_clicked dispatches the
+    # save-metadata action synchronously, so the tree is rebuilt before we assert
+    # (no settle-sleep, which could let a background readme reload overwrite it).
+    with patch.object(DatasetModel, "put_readme", return_value=None):
         main_window.readme_buffer.set_text(new_readme)
-
-        # Simulate save button click (linting off path or linting pass path)
-        with patch("dtool_lookup_gui.models.settings.settings.yaml_linting_enabled", False):
+        with patch.object(Settings, "yaml_linting_enabled",
+                          new_callable=PropertyMock, return_value=False):
             main_window.on_save_metadata_button_clicked(None)
-
-    # Give GTK a moment to process
-    await _asyncio.sleep(0.2)
 
     # The tree store must now contain entries matching the new YAML
     store = main_window.readme_tree_view.get_model()


### PR DESCRIPTION
Follow-up to #876 — clears all 4 remaining `xfail`s. Suite goes from **110 passed / 4 xfailed** to **114 passed / 0 xfailed**.

## #526 — README tree not rebuilt after save (real app bug, fixed)
`do_save_metadata` / `on_save_metadata_button_clicked` called `MainWindow._rebuild_readme_tree(...)`, which **did not exist** → `AttributeError`, tree never refreshed. Implemented it, mirroring the existing README-load population (`yaml.safe_load` → `store.clear()` → `fill_readme_tree_store`). Un-xfail'd the two save-metadata tests (and fixed their patching: `put_readme` at class level, `yaml_linting_enabled` via `PropertyMock`, synchronous asserts).

## #45 — base-URI listing timeout tests (test setup)
The configurable-timeout feature already works; the tests just never reached the listing path. Two fixes:
- **In-memory GSettings backend** (`GSETTINGS_BACKEND=memory` in conftest): the dconf backend can't persist with the session bus disabled, so a registered local base URI never reached `base_uri_list_box`. The memory backend gives fresh, isolated, working settings (and silences the dconf warnings).
- Tests now **register a local base URI** and trigger listing via the `show-base-uri` action (the listing/timeout path only runs for a real `DtoolBaseURIRow`), and filter `caplog` to the timeout message.

## Verification
- Full suite (CI-matched stack: pytest 9.1, no pytest-flake8): **114 passed, 0 xfailed, 0 failed**.
- `flake8 dtool_lookup_gui test --select=E9,F63,F7,F82`: clean.

Closes #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)