### PR TITLE
TST: fix flaky base-URI listing tests in serial coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,7 +59,12 @@ jobs:
         # run in virtual X server, see https://github.com/pygobject/pygobject-travis-ci-docker-examples
       - name: Test with pytest
         run: |
-            xvfb-run pytest -n $(python maintenance/collect_number_of_tests.py) --log-cli-level=DEBUG
+            N=$(python maintenance/collect_number_of_tests.py)
+            # Cap worker count: -n <number of tests> massively over-subscribes the
+            # runner (one worker per test), starving the asyncio event loop so that
+            # timing-sensitive GTK tests flake. Match test.yml's cap of 4.
+            if [ "$N" -gt 4 ] 2>/dev/null; then N=4; fi
+            xvfb-run --auto-servernum pytest -n "$N" --log-cli-level=DEBUG
 
       - name: setup pages
         uses: actions/configure-pages@v5

--- a/test/test_main_window_actions.py
+++ b/test/test_main_window_actions.py
@@ -775,31 +775,42 @@ async def test_do_select_dataset_row_by_uri_direct_call(populated_app_with_mock_
 # ---------------------------------------------------------------------------
 
 async def _add_local_base_uri_row(main_window, local_dataset_uri):
-    """Register the local dataset's base URI and return its DtoolBaseURIRow.
+    """Register the local dataset's base URI and return its (settled) DtoolBaseURIRow.
 
     The base-URI listing path only runs for a real DtoolBaseURIRow, and the
-    isolated test config has none registered, so register one explicitly.
+    isolated test config has none registered, so register one explicitly. The
+    returned row is settled: any listing auto-triggered by refresh/selection has
+    finished (row.task is None), so a subsequent show-base-uri spawns a fresh
+    listing instead of being skipped by the `if row.task is None` guard.
     """
     import os
     import asyncio as _asyncio
-    from dtool_lookup_gui.models.base_uris import LocalBaseURIModel
+    from dtoolcore.utils import generous_parse_uri
     from dtool_lookup_gui.widgets.base_uri_row import DtoolBaseURIRow
+    from dtool_lookup_gui.models.settings import settings
 
-    base_dir = os.path.dirname(local_dataset_uri)
-    try:
-        LocalBaseURIModel.add_directory(base_dir)
-    except ValueError:
-        pass  # already registered
+    # Register only this base URI. The in-memory GSettings backend persists across
+    # the (serial) suite, so replace rather than append to keep the list isolated.
+    settings.local_base_uris = [generous_parse_uri(os.path.dirname(local_dataset_uri)).path]
 
     main_window.activate_action("refresh-view")
+    base_row = None
     start = time.time()
     while time.time() - start < 10:
         base_rows = [r for r in main_window.base_uri_list_box.get_children()
                      if isinstance(r, DtoolBaseURIRow)]
         if base_rows:
-            return base_rows[0]
+            base_row = base_rows[0]
+            break
         await _asyncio.sleep(0.1)
-    return None
+    if base_row is None:
+        return None
+
+    # Wait for any auto-triggered listing to finish before handing the row back.
+    start = time.time()
+    while getattr(base_row, "task", None) is not None and time.time() - start < 10:
+        await _asyncio.sleep(0.1)
+    return base_row
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #877. That PR merged before this fix landed, so the **serial** "report and publish test coverage" job still flakes on `test_base_uri_listing_timeout_shows_error` (passes under parallel xdist, fails serially on CI).

**Cause:** `refresh-view` auto-triggers a base-URI listing (sets `row.task`); while it is still pending on a slow runner, the test's explicit `show-base-uri` is skipped by the `if row.task is None` guard, so the `timeout=1` listing never runs (observed: `assert []` plus lingering default-30s timeouts). In the serial suite the in-memory GSettings backend also leaks base-URI registrations across tests.

**Fix:** `_add_local_base_uri_row` now registers only this base URI (replacing the list for isolation) and waits for any auto-triggered listing (`row.task`) to finish before returning, so the subsequent `show-base-uri` reliably spawns a fresh listing.

Verified locally (parallel + serial). The serial coverage `build` job is the real check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)