### PR TITLE
docs: fix Read the Docs build (PyGObject 3.56 needs girepository-2.0)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,9 @@
 version: "2"
 
 build:
-  os: "ubuntu-22.04"
+  # 24.04 provides libgirepository-2.0-dev, which PyGObject >=3.56 needs and which
+  # does not exist on 22.04. Matches the Ubuntu version used by the CI workflows.
+  os: "ubuntu-24.04"
   tools:
     python: "3.10"
   apt_packages:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,8 +5,15 @@ build:
   tools:
     python: "3.10"
   apt_packages:
-    - "gir1.2-gtksource-4"
+    # Build deps for PyGObject (>=3.56 needs girepository-2.0, not just 1.0) and pycairo.
     - "libgirepository1.0-dev"
+    - "libgirepository-2.0-dev"
+    - "libcairo2-dev"
+    - "pkg-config"
+    # Typelibs needed when autodoc imports the GTK-based modules.
+    - "gir1.2-gtk-3.0"
+    - "gir1.2-gtksource-4"
+    - "libgtksourceview-4-0"
 
 python:
   install:


### PR DESCRIPTION
The Read the Docs build has been failing (red on every recent PR). Root cause, from the RTD build log:

```
Run-time dependency girepository-2.0 found: NO  (tried pkg-config and cmake)
../meson.build:35:9: ERROR: Dependency 'girepository-2.0' is required but not found.
error: metadata-generation-failed  ×  PyGObject
```

`pip install .` builds **PyGObject 3.56.3** (pulled by `PyGObject>=3.50`), which now requires the **`girepository-2.0`** dev library, but `.readthedocs.yaml` only installed the old `libgirepository1.0-dev`.

**Fix:** add the apt packages PyGObject 3.56 / pycairo need to build (`libgirepository-2.0-dev`, `libcairo2-dev`, `pkg-config`) plus the GTK/GtkSource typelibs autodoc imports (`gir1.2-gtk-3.0`, `libgtksourceview-4-0`) — matching what `test.yml` already installs.

The RTD build triggered by this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)