### PR TITLE
BUG: do_renew_token forces authentication regardless of disable_authentication

### DIFF
--- a/dtool_lookup_gui/main.py
+++ b/dtool_lookup_gui/main.py
@@ -373,8 +373,13 @@ class Application(Gtk.Application):
 
         async def retrieve_token(auth_url, username, password):
             try:
+                # Force the authenticating client: renew-token is an explicit
+                # credentials-based authentication, so it must not depend on the
+                # configured disable_authentication (which would otherwise yield an
+                # UnauthenticatedLookupClient that has no authenticate()).
                 async with ConfigurationBasedLookupClient(
-                        auth_url=auth_url, username=username, password=password) as lookup_client:
+                        auth_url=auth_url, username=username, password=password,
+                        disable_authentication=False) as lookup_client:
                     token = await lookup_client.authenticate()
             except InvalidURL as e:
                 logger.error(

--- a/test/test_main_app_actions.py
+++ b/test/test_main_app_actions.py
@@ -366,3 +366,35 @@ async def test_do_renew_token_wrong_credentials(running_app, caplog):
     msg = error_records[-1].message
     assert "password" in msg.lower() or "credential" in msg.lower() or "incorrect" in msg.lower(), \
         f"Expected credential error message, got: {msg!r}"
+
+
+@pytest.mark.asyncio
+async def test_do_renew_token_forces_authentication(running_app):
+    """renew-token must request an authenticating client regardless of the
+    configured disable_authentication.
+
+    Regression: the ConfigurationBasedLookupClient factory returns an
+    UnauthenticatedLookupClient (which has no authenticate()) when
+    disable_authentication is True, so do_renew_token must pass
+    disable_authentication=False explicitly.
+    """
+    import asyncio as _asyncio
+
+    value = MagicMock()
+    value.unpack.return_value = ("user", "pass", "https://auth.example.com/token")
+
+    with patch("dtool_lookup_gui.main.ConfigurationBasedLookupClient") as MockClient, \
+            patch.object(running_app, "emit") as mock_emit:
+        MockClient.return_value.__aenter__ = AsyncMock(return_value=MockClient.return_value)
+        MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+        MockClient.return_value.authenticate = AsyncMock(return_value="new-token")
+
+        running_app.do_renew_token(None, value)
+        await _asyncio.sleep(0.2)
+
+    # The factory must be told to authenticate, irrespective of the config.
+    assert MockClient.call_args.kwargs.get("disable_authentication") is False
+    # On success the token-renewed signal is emitted.
+    assert any(call.args and call.args[0] == "token-renewed"
+               for call in mock_emit.call_args_list), \
+        "Expected 'token-renewed' to be emitted after successful authentication"


### PR DESCRIPTION
Fixes the last known app bug from the triage. `do_renew_token` is an explicit, credentials-based authentication, but it called the `ConfigurationBasedLookupClient` factory without overriding `disable_authentication`. When the user's config has `disable_authentication=True`, the factory returns an `UnauthenticatedLookupClient`, which has **no `authenticate()`** → `AttributeError`, surfaced via the generic handler as the confusing *"Authentication failed: 'UnauthenticatedLookupClient' object has no attribute 'authenticate'"*.

**Fix:** pass `disable_authentication=False` to the factory so the authenticating client is always selected for token renewal.

Verified the factory behavior directly:
- default config (`disable_authentication=True`) → `UnauthenticatedLookupClient` (no `authenticate`) — the bug
- `disable_authentication=False` → `ConfigurationBasedAuthenticatedLookupClient` (has `authenticate`) — the fix

Adds a regression test asserting the factory is requested with `disable_authentication=False` and that `token-renewed` is emitted on success. Full suite: 115 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)