### PR TITLE
DOC: correct CHANGELOG for 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ Change log for dtool-lookup-gui
   child processes can initialise GTK; add smoke-test step that verifies
   the bundle starts without crashing before uploading artifacts
 - BUG: fix Linux bundle crashing with `Unrecognized image file format` on PNG;
-  explicitly bundle `libgdk-pixbuf-2.0.so`, `libpng16.so`, `libjpeg.so` and
-  related libraries; also bundle GdkPixbuf loader `.so` files and regenerate
-  `loaders.cache` in CI so the bundled app can decode images without a system
-  GdkPixbuf installation
+  rely on GdkPixbuf's built-in PNG/JPEG loaders (compiled into
+  `libgdk-pixbuf-2.0.so` on Ubuntu 24.04) and bundle the GdkPixbuf loader
+  `.so` files with a path-rewritten `loaders.cache`. `libpng16`/`libjpeg` are
+  deliberately NOT bundled separately — doing so loaded two copies of `libpng16`
+  (one from the bundle, one via the system `libgdk-pixbuf` RPATH) and corrupted
+  libpng's global state
 - BUG: fix Linux bundle missing `GObject.type_register` and other `gi.overrides`
   Python wrappers; PyInstaller's GI hook skips overrides when module introspection
   fails; explicitly collect all `gi.overrides` submodules as hidden imports
@@ -54,10 +56,14 @@ Change log for dtool-lookup-gui
 - Dataset name dialog now shows an inline error message when the name is
   empty or contains invalid characters, instead of silently doing nothing
   on Apply — fixes #199
-
-0.7.3 (unreleased)
--------------------
-
+- BUG: fix token renewal crashing with `AttributeError: 'UnauthenticatedLookupClient'
+  object has no attribute 'authenticate'` when authentication is disabled in the
+  configuration; the renew-token action now always requests an authenticating
+  client — fixes #882
+- BUG: fix several main-window error/warning handlers referencing an undefined
+  `logger` (only `_logger` was defined), which raised `NameError` instead of
+  reporting the problem (e.g. failed add-local-directory, base-URI listing
+  timeout, dataset copy, create-dataset) — fixes #875
 - ``save-metadata`` action: saving README metadata is now a proper window
   action, independently testable and keyboard-shortcut-bindable
 - ``copy-dataset`` action: dataset copy is now a ``(source_uri, dest_uri)``


### PR DESCRIPTION
Corrections found while re-reviewing the 0.7.3 changelog against the actual commits and final code:

1. **Merge duplicated section** — there were two `0.7.3 (unreleased)` headers; folded the second (save-metadata / copy-dataset / add-local-directory actions) into the one section.
2. **Fix the GdkPixbuf entry** — it claimed the bundle *"explicitly bundles `libpng16.so`, `libjpeg.so`"*, but the final approach deliberately does **not** (that caused two copies of libpng16 and corrupted libpng's global state — see `dtool-lookup-gui-linux-one-file.spec:155`). The bundle relies on GdkPixbuf's built-in PNG/JPEG loaders plus the loader `.so`s with a path-rewritten `loaders.cache`. The old entry described the reverted intermediate approach.
3. **Add missing entries**:
   - `do_renew_token` crashed with `AttributeError: 'UnauthenticatedLookupClient' object has no attribute 'authenticate'` when authentication is disabled (#882).
   - several main-window error/warning handlers referenced an undefined `logger` (only `_logger` exists) → `NameError` instead of reporting the problem (#875).

🤖 Generated with [Claude Code](https://claude.com/claude-code)