### PR TITLE
BUG/TST: fix dependency-graph & log-handler crashes, expand test coverage

### DIFF
--- a/dtool_lookup_gui/models/simple_graph.py
+++ b/dtool_lookup_gui/models/simple_graph.py
@@ -137,7 +137,11 @@ class GraphLayout:
 
     def _compute_spring_energy_and_forces(self, pos):
         nb_vertices = self.graph.nb_vertices
-        if nb_vertices <= 1:
+        # With no edges there are no spring forces; bail out before building the
+        # neighbor list. An empty edge list would otherwise become a float NumPy
+        # array and fail when used to index positions (raised on graphs whose
+        # datasets have no dependencies).
+        if nb_vertices <= 1 or self.graph.nb_edges == 0:
             return 0, np.zeros_like(pos)
 
         # Neighbor list (edge list)

--- a/dtool_lookup_gui/utils/logging.py
+++ b/dtool_lookup_gui/utils/logging.py
@@ -216,8 +216,8 @@ class AppendingGtkEntryBufferHandler(GtkEntryBufferHandler):
         if len(msg.splitlines()) > self._max_lines:
             new_text = "\n".join([
                 *msg.splitlines()[:self._max_lines//2],
-                '...'
-                * msg.splitlines()[self._max_lines//2+1:]
+                '...',
+                *msg.splitlines()[self._max_lines//2+1:]
             ])
         else: # crop older messages if too long
             original_text = self._buffer.get_text()
@@ -227,7 +227,7 @@ class AppendingGtkEntryBufferHandler(GtkEntryBufferHandler):
                 lines_to_remove = len(new_text.splitlines()) - self._max_lines
                 new_text = "\n".join(new_text.splitlines()[lines_to_remove:])
 
-        self._buffer.set_text(new_text)
+        self._buffer.set_text(new_text, -1)
 
 
 class SingleMessageGtkEntryBufferHandler(GtkEntryBufferHandler):
@@ -238,12 +238,12 @@ class SingleMessageGtkEntryBufferHandler(GtkEntryBufferHandler):
         if len(msg.splitlines()) > self._max_lines:
             new_text = "\n".join([
                 *msg.splitlines()[:self._max_lines//2],
-                '...'
-                * msg.splitlines()[self._max_lines//2+1:]
+                '...',
+                *msg.splitlines()[self._max_lines//2+1:]
             ])
         else:
             new_text = msg
-        self._buffer.set_text(new_text)
+        self._buffer.set_text(new_text, -1)
 
 
 class SingleMessageGtkLabelHandler(GtkLabelHandler):

--- a/test/test_dependency_graph.py
+++ b/test/test_dependency_graph.py
@@ -128,3 +128,96 @@ async def test_dependency_graph_success_builds_graph():
     uuids = {v["uuid"] for v in graph.graph.vertex_properties}
     assert "root-uuid" in uuids
     assert "child-uuid" in uuids
+
+
+# Valid UUIDs are required for edges: trace_dependencies only links a child to a
+# parent when the parent identifier passes is_uuid().
+ROOT = "11111111-1111-1111-1111-111111111111"
+CHILD = "22222222-2222-2222-2222-222222222222"
+MISSING = "33333333-3333-3333-3333-333333333333"
+
+
+@pytest.mark.asyncio
+async def test_edge_built_between_existing_datasets():
+    graph = DependencyGraph()
+    datasets = [
+        {"uuid": ROOT, "name": "root"},
+        {"uuid": CHILD, "name": "child", "derived_from": [ROOT]},
+    ]
+    lookup = MagicMock()
+    lookup.get_graph_by_uuid = AsyncMock(return_value=datasets)
+
+    await graph.trace_dependencies(lookup, root_uuid=ROOT)
+
+    assert graph.graph.nb_vertices == 2
+    assert graph.graph.nb_edges == 1
+    assert graph.missing_uuids == []
+
+
+@pytest.mark.asyncio
+async def test_missing_parent_added_as_placeholder_vertex():
+    graph = DependencyGraph()
+    datasets = [
+        {"uuid": CHILD, "name": "child", "derived_from": [MISSING]},
+    ]
+    lookup = MagicMock()
+    lookup.get_graph_by_uuid = AsyncMock(return_value=datasets)
+
+    await graph.trace_dependencies(lookup, root_uuid=CHILD)
+
+    assert MISSING in graph.missing_uuids
+    assert graph.graph.nb_vertices == 2  # child plus the missing placeholder
+    assert graph.graph.nb_edges == 1
+    kinds = {v["uuid"]: v["kind"] for v in graph.graph.vertex_properties}
+    assert kinds[MISSING] == "does-not-exist"
+
+
+@pytest.mark.asyncio
+async def test_multi_page_results_are_extended():
+    graph = DependencyGraph()
+    call_count = 0
+
+    async def side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            pagination = kwargs.get("pagination", {})
+            pagination.update({"total": 2, "page_size": 1, "page": 1,
+                               "first_page": 1, "last_page": 2, "total_pages": 2})
+            return [{"uuid": ROOT, "name": "root"}]
+        return [{"uuid": CHILD, "name": "child", "derived_from": [ROOT]}]
+
+    lookup = MagicMock()
+    lookup.get_graph_by_uuid = AsyncMock(side_effect=side_effect)
+
+    await graph.trace_dependencies(lookup, root_uuid=ROOT)
+
+    assert call_count == 2
+    assert graph.graph.nb_vertices == 2
+    assert graph.graph.nb_edges == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_dependency_keys_are_ignored():
+    graph = DependencyGraph()
+    lookup = MagicMock()
+    lookup.get_graph_by_uuid = AsyncMock(return_value=[])
+
+    # An int is neither a JSON string nor a list -> coerced to None with a warning.
+    await graph.trace_dependencies(lookup, root_uuid=ROOT, dependency_keys=123)
+
+    _, kwargs = lookup.get_graph_by_uuid.call_args
+    assert kwargs["dependency_keys"] is None
+
+
+@pytest.mark.asyncio
+async def test_dependency_keys_json_string_is_parsed():
+    graph = DependencyGraph()
+    lookup = MagicMock()
+    lookup.get_graph_by_uuid = AsyncMock(return_value=[])
+
+    await graph.trace_dependencies(
+        lookup, root_uuid=ROOT, dependency_keys='["readme.derived_from.uuid"]')
+
+    _, kwargs = lookup.get_graph_by_uuid.call_args
+    assert kwargs["dependency_keys"] == ["readme.derived_from.uuid"]

--- a/test/test_log_window.py
+++ b/test/test_log_window.py
@@ -1,0 +1,101 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for views.log_window.
+
+The LogWindow the main window builds during activation is reached via the
+running_app fixture and its non-modal signal/action handlers are exercised
+directly. The modal save handler (Gtk.FileChooserDialog.run) needs user
+interaction and is out of scope.
+"""
+import logging
+
+import pytest
+
+from gi.repository import GLib
+
+from dtool_lookup_gui.views.main_window import MainWindow
+
+
+def _log_window(app):
+    main_window = [w for w in app.get_windows() if isinstance(w, MainWindow)][0]
+    return main_window.log_window
+
+
+def _buffer_text(buf):
+    return buf.get_text(buf.get_start_iter(), buf.get_end_iter(), False)
+
+
+@pytest.mark.asyncio
+async def test_do_loglevel_changed_updates_combo_box(running_app):
+    log_window = _log_window(running_app)
+    model = log_window.loglevel_combo_box.get_model()
+    current = model[log_window.loglevel_combo_box.get_active_iter()][0]
+    target = logging.DEBUG if current != logging.DEBUG else logging.INFO
+
+    log_window.do_loglevel_changed(None, GLib.Variant.new_uint16(target))
+
+    active = model[log_window.loglevel_combo_box.get_active_iter()][0]
+    assert active == target
+
+
+@pytest.mark.asyncio
+async def test_on_show_does_not_raise(running_app):
+    log_window = _log_window(running_app)
+    log_window.on_show(None)
+
+
+@pytest.mark.asyncio
+async def test_on_delete_hides_instead_of_destroying(running_app):
+    log_window = _log_window(running_app)
+    assert log_window.on_delete(None, None) is True
+
+
+@pytest.mark.asyncio
+async def test_on_log_switch_state_set_does_not_raise(running_app):
+    log_window = _log_window(running_app)
+    log_window.on_log_switch_state_set(log_window.log_switch, True)
+
+
+@pytest.mark.asyncio
+async def test_on_clear_clicked_empties_buffer(running_app):
+    log_window = _log_window(running_app)
+    log_window.log_buffer.set_text("some log content")
+    log_window.on_clear_clicked(None)
+    assert _buffer_text(log_window.log_buffer) == ""
+
+
+@pytest.mark.asyncio
+async def test_on_copy_clicked_does_not_raise(running_app):
+    log_window = _log_window(running_app)
+    log_window.log_buffer.set_text("copy me")
+    log_window.on_copy_clicked(None)
+
+
+@pytest.mark.asyncio
+async def test_on_destroy_removes_log_handler(running_app):
+    log_window = _log_window(running_app)
+    root_logger = logging.getLogger()
+    assert log_window.log_handler in root_logger.handlers
+    log_window.on_destroy(None)
+    assert log_window.log_handler not in root_logger.handlers

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,0 +1,167 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for utils.logging.
+
+The GTK buffer log handlers are exercised against real Gtk.TextBuffer / Label /
+InfoBar widgets (no window required). Covered are the handlers actually wired up
+in the app (appending text buffer, single-message info bar) plus the working
+prepending text-buffer handler, the max_lines validation, and the emit error
+path. The Gtk*EntryBufferHandler classes are unused in the app and currently
+broken (Gtk.EntryBuffer.set_text arity), so their emit paths are not asserted
+here.
+"""
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+from dtool_lookup_gui.utils import logging as L
+
+
+def _record(msg, level=logging.INFO):
+    return logging.LogRecord("test", level, __file__, 0, msg, None, None)
+
+
+def _text(buffer):
+    return buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), False)
+
+
+# ===========================================================================
+# helpers and filters
+# ===========================================================================
+
+def test_log_nested_emits_one_call_per_line():
+    lines = []
+    L._log_nested(lines.append, {"a": 1, "b": {"c": 2}})
+    assert len(lines) > 1
+    assert any('"a"' in line for line in lines)
+
+
+def test_default_filter_blocks_excluded_pattern():
+    assert L.DefaultFilter().filter(_record("Unclosed client session")) is False
+
+
+def test_default_filter_allows_unmatched_message():
+    assert L.DefaultFilter().filter(_record("a normal message")) is True
+
+
+# ===========================================================================
+# GtkBufferHandler.max_lines validation
+# ===========================================================================
+
+def test_max_lines_none_means_no_limit():
+    assert L.GtkBufferHandler(max_lines=None).max_lines is None
+
+
+def test_max_lines_accepts_non_negative_int():
+    assert L.GtkBufferHandler(max_lines=5).max_lines == 5
+
+
+@pytest.mark.parametrize("bad", [-1, "x", 1.5])
+def test_max_lines_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        L.GtkBufferHandler(max_lines=bad)
+
+
+def test_emit_routes_exceptions_to_handle_error():
+    handler = L.FormattedAppendingGtkTextBufferHandler(text_buffer=Gtk.TextBuffer())
+    handler.handleError = MagicMock()
+    handler._insert_into_buffer = MagicMock(side_effect=RuntimeError("boom"))
+    handler.emit(_record("x"))
+    handler.handleError.assert_called_once()
+
+
+# ===========================================================================
+# Appending text-buffer handler (used by the log window)
+# ===========================================================================
+
+def test_appending_text_buffer_writes_message():
+    buf = Gtk.TextBuffer()
+    handler = L.FormattedAppendingGtkTextBufferHandler(text_buffer=buf)
+    handler.emit(_record("hello append"))
+    assert "hello append" in _text(buf)
+
+
+def test_appending_text_buffer_crops_to_max_lines():
+    buf = Gtk.TextBuffer()
+    handler = L.FormattedAppendingGtkTextBufferHandler(text_buffer=buf, max_lines=3)
+    for i in range(10):
+        handler.emit(_record(f"line{i}"))
+    # newest message survives, line count stays bounded
+    assert "line9" in _text(buf)
+    assert buf.get_line_count() <= 4
+
+
+# ===========================================================================
+# Prepending text-buffer handler
+# ===========================================================================
+
+def test_prepending_text_buffer_inserts_newest_first():
+    buf = Gtk.TextBuffer()
+    handler = L.FormattedPrependingGtkTextBufferHandler(text_buffer=buf)
+    handler.emit(_record("first"))
+    handler.emit(_record("second"))
+    text = _text(buf)
+    assert text.index("second") < text.index("first")
+
+
+def test_prepending_text_buffer_crops_to_max_lines():
+    buf = Gtk.TextBuffer()
+    handler = L.FormattedPrependingGtkTextBufferHandler(text_buffer=buf, max_lines=2)
+    for i in range(6):
+        handler.emit(_record(f"p{i}"))
+    assert buf.get_line_count() <= 3
+
+
+# ===========================================================================
+# Label / InfoBar handlers (info bar used by the main window)
+# ===========================================================================
+
+def test_label_handler_keeps_last_lines_when_too_long():
+    label = Gtk.Label()
+    handler = L.FormattedSingleMessageGtkLabelHandler(label=label, max_lines=1)
+    handler.emit(_record("a\nb\nc"))
+    assert label.get_text().strip().endswith("c")
+
+
+def test_infobar_handler_sets_label_and_reveals():
+    label = Gtk.Label()
+    info_bar = Gtk.InfoBar()
+    handler = L.FormattedSingleMessageGtkInfoBarHandler(label=label, info_bar=info_bar)
+    handler.emit(_record("important"))
+    assert "important" in label.get_text()
+    assert info_bar.get_revealed() is True
+
+
+# ===========================================================================
+# Entry-buffer handler construction (emit path is broken and unused)
+# ===========================================================================
+
+def test_entry_buffer_handler_construction_uses_default_max_lines():
+    handler = L.AppendingGtkEntryBufferHandler(entry_buffer=Gtk.EntryBuffer())
+    assert handler.max_lines == L.DEFAULT_ENTRY_MAX_LINES

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -25,11 +25,9 @@
 
 The GTK buffer log handlers are exercised against real Gtk.TextBuffer / Label /
 InfoBar widgets (no window required). Covered are the handlers actually wired up
-in the app (appending text buffer, single-message info bar) plus the working
-prepending text-buffer handler, the max_lines validation, and the emit error
-path. The Gtk*EntryBufferHandler classes are unused in the app and currently
-broken (Gtk.EntryBuffer.set_text arity), so their emit paths are not asserted
-here.
+in the app (appending text buffer, single-message info bar) plus the
+prepending text-buffer handler, the entry-buffer handlers, the max_lines
+validation, and the emit error path.
 """
 import logging
 from unittest.mock import MagicMock
@@ -159,9 +157,42 @@ def test_infobar_handler_sets_label_and_reveals():
 
 
 # ===========================================================================
-# Entry-buffer handler construction (emit path is broken and unused)
+# Entry-buffer handlers
 # ===========================================================================
 
 def test_entry_buffer_handler_construction_uses_default_max_lines():
     handler = L.AppendingGtkEntryBufferHandler(entry_buffer=Gtk.EntryBuffer())
     assert handler.max_lines == L.DEFAULT_ENTRY_MAX_LINES
+
+
+def test_appending_entry_buffer_keeps_latest_message():
+    buf = Gtk.EntryBuffer()
+    handler = L.AppendingGtkEntryBufferHandler(entry_buffer=buf, max_lines=3)
+    for i in range(5):
+        handler.emit(_record(f"entry{i}"))
+    text = buf.get_text()
+    assert "entry4" in text
+    assert len(text.splitlines()) <= 3
+
+
+def test_appending_entry_buffer_shortens_multiline_message():
+    buf = Gtk.EntryBuffer()
+    handler = L.AppendingGtkEntryBufferHandler(entry_buffer=buf, max_lines=2)
+    handler.emit(_record("a\nb\nc\nd\ne"))
+    assert "..." in buf.get_text()
+
+
+def test_single_message_entry_buffer_stores_only_last_message():
+    buf = Gtk.EntryBuffer()
+    handler = L.SingleMessageGtkEntryBufferHandler(entry_buffer=buf, max_lines=5)
+    handler.emit(_record("first"))
+    handler.emit(_record("second"))
+    assert buf.get_text() == "second"
+
+
+def test_single_message_entry_buffer_shortens_multiline_message():
+    buf = Gtk.EntryBuffer()
+    handler = L.SingleMessageGtkEntryBufferHandler(entry_buffer=buf, max_lines=2)
+    handler.emit(_record("a\nb\nc\nd\ne"))
+    # The middle is elided with an ellipsis marker.
+    assert "..." in buf.get_text()

--- a/test/test_progressbar.py
+++ b/test/test_progressbar.py
@@ -1,0 +1,103 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for the ProgressBar context manager (utils.progressbar).
+
+ProgressBar mimics click.progressbar: with no widget it only logs; with a
+widget it drives set_fraction/set_step/set_text. The widget is a mock, so no
+GTK widget tree is needed.
+"""
+from unittest.mock import MagicMock
+
+from dtool_lookup_gui.utils.progressbar import ProgressBar
+
+
+# --- no-widget (logging-only) behaviour ------------------------------------
+
+def test_context_manager_without_widget_runs():
+    with ProgressBar(length=10, label="Copying") as bar:
+        assert bar is not None
+        bar.update(5)  # must not raise without a widget
+
+
+def test_label_property_round_trip():
+    bar = ProgressBar(length=10)
+    bar.label = "new label"
+    assert bar.label == "new label"
+
+
+def test_item_show_func_property_round_trip():
+    bar = ProgressBar(length=10, label="x")
+
+    def show(step):
+        return f"item{step}"
+
+    bar.item_show_func = show
+    assert bar.item_show_func is show
+
+
+# --- with a widget ---------------------------------------------------------
+
+def test_enter_initializes_widget_fraction():
+    widget = MagicMock()
+    with ProgressBar(length=10, label="Copying", pb=widget):
+        pass
+    widget.set_fraction.assert_any_call(0.0)
+    widget.set_step.assert_any_call(0, 10)
+
+
+def test_update_advances_widget_fraction_and_step():
+    widget = MagicMock()
+    with ProgressBar(length=10, label="Copying", pb=widget) as bar:
+        bar.update(5)
+    widget.set_fraction.assert_any_call(0.5)
+    widget.set_step.assert_any_call(5, 10)
+
+
+def test_update_accumulates_steps():
+    widget = MagicMock()
+    bar = ProgressBar(length=4, pb=widget)
+    bar.update(1)
+    bar.update(1)
+    widget.set_fraction.assert_called_with(0.5)  # 2/4
+
+
+def test_set_text_uses_label_on_widget():
+    widget = MagicMock()
+    bar = ProgressBar(length=10, label="Copying", pb=widget)
+    bar.label = "Downloading"
+    widget.set_text.assert_called_with("Downloading")
+
+
+def test_set_text_with_item_show_func_on_widget():
+    widget = MagicMock()
+    bar = ProgressBar(length=10, label="Copying", pb=widget)
+    bar.item_show_func = lambda step: f"file{step}"
+    widget.set_text.assert_called()
+
+
+def test_without_label_hides_widget_text():
+    widget = MagicMock()
+    with ProgressBar(length=10, pb=widget):
+        pass
+    widget.set_show_text.assert_called_with(False)

--- a/test/test_search_state.py
+++ b/test/test_search_state.py
@@ -1,0 +1,198 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for the SearchState client model (pagination/sorting/search)."""
+import pytest
+
+from dtool_lookup_gui.models.search_state import SearchState
+
+
+@pytest.fixture
+def state():
+    return SearchState()
+
+
+# --- defaults and resets ---------------------------------------------------
+
+def test_defaults(state):
+    assert state.search_text == ""
+    assert state.page_size == 10
+    assert state.current_page == 1
+    assert state.last_page == 1
+    assert state.total_pages == 1
+    assert state.total_number_of_entries == 0
+    assert state.sort_fields == ["uri"]
+    assert state.sort_order == [1]
+    assert state.fetching_results is False
+
+
+def test_reset_pagination(state):
+    state.last_page = 9
+    state._current_page = 4
+    state.reset_pagination()
+    assert state.current_page == 1
+    assert state.last_page == 1
+
+
+def test_reset_sorting(state):
+    state.sort_fields = ["name"]
+    state.sort_order = [-1]
+    state.reset_sorting()
+    assert state.sort_fields == ["uri"]
+    assert state.sort_order == [1]
+
+
+# --- search text -----------------------------------------------------------
+
+def test_search_text_round_trip(state):
+    state.search_text = "toluene"
+    assert state.search_text == "toluene"
+
+
+# --- current_page clamping -------------------------------------------------
+
+def test_current_page_clamped_to_minimum(state):
+    state.current_page = 0
+    assert state.current_page == 1
+
+
+def test_current_page_clamped_to_last_page(state):
+    state.last_page = 5
+    state.current_page = 99
+    assert state.current_page == 5
+
+
+def test_current_page_accepts_value_in_range(state):
+    state.last_page = 5
+    state.current_page = 3
+    assert state.current_page == 3
+
+
+# --- page-bound validation -------------------------------------------------
+
+@pytest.mark.parametrize("setter", ["last_page", "first_page", "page_size"])
+def test_positive_int_setters_reject_invalid(state, setter):
+    with pytest.raises(ValueError):
+        setattr(state, setter, 0)
+    with pytest.raises(ValueError):
+        setattr(state, setter, "x")
+
+
+def test_page_size_round_trip(state):
+    state.page_size = 50
+    assert state.page_size == 50
+
+
+def test_fetching_results_requires_bool(state):
+    state.fetching_results = True
+    assert state.fetching_results is True
+    with pytest.raises(ValueError):
+        state.fetching_results = "yes"
+
+
+# --- sort fields -----------------------------------------------------------
+
+def test_sort_fields_accepts_single_string(state):
+    state.sort_fields = "name"
+    assert state.sort_fields == ["name"]
+
+
+def test_sort_fields_rejects_non_list(state):
+    with pytest.raises(ValueError):
+        state.sort_fields = 5
+
+
+def test_sort_fields_rejects_unknown_field(state):
+    with pytest.raises(ValueError):
+        state.sort_fields = ["not_a_field"]
+
+
+# --- sort order ------------------------------------------------------------
+
+def test_sort_order_accepts_single_int(state):
+    # sort_fields defaults to one field, so a single-element order is valid.
+    state.sort_order = 1
+    assert state.sort_order == [1]
+
+
+def test_sort_order_rejects_non_list(state):
+    with pytest.raises(ValueError):
+        state.sort_order = "asc"
+
+
+def test_sort_order_length_must_match_sort_fields(state):
+    state.sort_fields = ["name", "uri"]
+    with pytest.raises(ValueError):
+        state.sort_order = [1]
+
+
+# --- ingest helpers --------------------------------------------------------
+
+def test_ingest_pagination_information(state):
+    state.ingest_pagination_information(
+        {"total": 284, "total_pages": 29, "first_page": 1, "last_page": 29, "page": 3})
+    assert state.first_page == 1
+    assert state.last_page == 29
+    assert state.current_page == 3
+    assert state.total_pages == 29
+    assert state.total_number_of_entries == 284
+
+
+def test_ingest_pagination_information_uses_defaults_when_empty(state):
+    state.ingest_pagination_information({})
+    assert state.first_page == 1
+    assert state.last_page == 1
+    assert state.current_page == 1
+    assert state.total_number_of_entries == 0
+
+
+def test_ingest_sorting_information(state):
+    state.ingest_sorting_information({"sort": {"base_uri": 1, "name": -1}})
+    assert state.sort_fields == ["base_uri", "name"]
+    assert state.sort_order == [1, -1]
+
+
+# --- next/previous page navigation -----------------------------------------
+
+def test_next_page_increments_within_bounds(state):
+    state.last_page = 5
+    state.current_page = 2
+    assert state.next_page == 3
+
+
+def test_next_page_caps_at_last_page(state):
+    state.last_page = 5
+    state.current_page = 5
+    assert state.next_page == 5
+
+
+def test_previous_page_decrements_within_bounds(state):
+    state.last_page = 5
+    state.current_page = 3
+    assert state.previous_page == 2
+
+
+def test_previous_page_floors_at_first_page(state):
+    state.last_page = 5
+    state.current_page = 1
+    assert state.previous_page == 1

--- a/test/test_settings_dialog.py
+++ b/test/test_settings_dialog.py
@@ -1,0 +1,184 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for views.settings_dialog.
+
+The pure _get_base_uri helper is tested directly. The signal handlers are
+exercised against the real SettingsDialog the main window builds during app
+activation (reached via the running_app fixture). The dtool lookup-server
+Config global is patched where a handler writes to it, so no config file or
+server is touched. The modal file-chooser handlers (import/export/renew) need
+user interaction and are out of scope here.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import dtoolcore
+
+from dtool_lookup_gui.views.main_window import MainWindow
+from dtool_lookup_gui.views.settings_dialog import _get_base_uri
+from dtool_lookup_gui.models.settings import settings
+
+_CONFIG = "dtool_lookup_gui.views.settings_dialog.Config"
+
+
+def _settings_dialog(app):
+    main_window = [w for w in app.get_windows() if isinstance(w, MainWindow)][0]
+    return main_window.settings_dialog
+
+
+# ===========================================================================
+# _get_base_uri (pure)
+# ===========================================================================
+
+def test_get_base_uri_s3():
+    assert _get_base_uri("DTOOL_S3_ENDPOINT_mybucket") == "s3://mybucket"
+
+
+def test_get_base_uri_smb():
+    assert _get_base_uri("DTOOL_SMB_SERVER_NAME_myserver") == "smb://myserver"
+
+
+def test_get_base_uri_unknown_key_returns_none():
+    assert _get_base_uri("DTOOL_SOMETHING_ELSE") is None
+
+
+# ===========================================================================
+# SettingsDialog signal handlers
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_yaml_linting_switch_updates_settings(running_app):
+    dialog = _settings_dialog(running_app)
+    dialog.on_yaml_linting_switch_state_set(dialog.yaml_linting_switch, True)
+    assert settings.yaml_linting_enabled is True
+    dialog.on_yaml_linting_switch_state_set(dialog.yaml_linting_switch, False)
+    assert settings.yaml_linting_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_verify_ssl_switch_writes_config(running_app):
+    dialog = _settings_dialog(running_app)
+    with patch(_CONFIG) as mock_config:
+        dialog.on_verify_ssl_certificate_switch_state_set(None, False)
+        assert mock_config.verify_ssl is False
+
+
+@pytest.mark.asyncio
+async def test_disable_authentication_switch_toggles_sensitivity(running_app):
+    dialog = _settings_dialog(running_app)
+    with patch(_CONFIG) as mock_config:
+        dialog.on_disable_authentication_switch_state_set(None, True)
+        assert mock_config.disable_authentication is True
+        # Authentication-related widgets are disabled when auth is off.
+        assert dialog.authenticator_url_entry.get_sensitive() is False
+        assert dialog.renew_token_button.get_sensitive() is False
+        assert dialog.token_entry.get_sensitive() is False
+
+        dialog.on_disable_authentication_switch_state_set(None, False)
+        assert dialog.authenticator_url_entry.get_sensitive() is True
+        assert dialog.token_entry.get_sensitive() is True
+
+
+@pytest.mark.asyncio
+async def test_on_dtool_config_changed_refreshes(running_app):
+    dialog = _settings_dialog(running_app)
+    with patch.object(dialog, "_refresh_settings_dialog") as mock_refresh:
+        dialog.on_dtool_config_changed(None)
+        mock_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_item_download_directory_file_set_updates_settings(running_app, tmp_path):
+    dialog = _settings_dialog(running_app)
+    widget = MagicMock()
+    widget.get_file.return_value.get_path.return_value = str(tmp_path)
+    dialog.on_item_download_directory_file_chooser_button_file_set(widget)
+    assert settings.item_download_directory == str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_item_download_directory_file_set_ignores_none(running_app):
+    dialog = _settings_dialog(running_app)
+    before = settings.item_download_directory
+    widget = MagicMock()
+    widget.get_file.return_value.get_path.return_value = None
+    dialog.on_item_download_directory_file_chooser_button_file_set(widget)
+    assert settings.item_download_directory == before
+
+
+@pytest.mark.asyncio
+async def test_on_delete_writes_back_config(running_app):
+    dialog = _settings_dialog(running_app)
+    dialog.lookup_url_entry.set_text("https://lookup.example.com")
+    dialog.dtool_user_full_name_entry.set_text("Jane Doe")
+    dialog.dtool_user_email_entry.set_text("jane@example.com")
+
+    with patch(_CONFIG) as mock_config:
+        dialog.on_delete(None, None)
+        assert mock_config.lookup_url == "https://lookup.example.com"
+
+    # Basic dtool config is written through dtoolcore to the isolated config file.
+    assert dtoolcore.utils.get_config_value("DTOOL_USER_FULL_NAME") == "Jane Doe"
+    assert dtoolcore.utils.get_config_value("DTOOL_USER_EMAIL") == "jane@example.com"
+
+
+@pytest.mark.asyncio
+async def test_refresh_handles_unset_config(running_app):
+    dialog = _settings_dialog(running_app)
+    with patch(_CONFIG) as mock_config:
+        mock_config.lookup_url = None
+        mock_config.token = None
+        mock_config.auth_url = None
+        mock_config.verify_ssl = None
+        mock_config.disable_authentication = None
+        dialog._refresh_settings_dialog()
+
+    # Unset lookup config clears the corresponding entries.
+    assert dialog.lookup_url_entry.get_text() == ""
+    assert dialog.token_entry.get_text() == ""
+    assert dialog.authenticator_url_entry.get_text() == ""
+
+
+@pytest.mark.asyncio
+async def test_refresh_populates_entries_from_config(running_app, tmp_path):
+    dialog = _settings_dialog(running_app)
+    readme_template = tmp_path / "readme_template.yml"
+    readme_template.write_text("project: example\n")
+    dtoolcore.utils.write_config_value_to_file(
+        "DTOOL_README_TEMPLATE_FPATH", str(readme_template))
+
+    with patch(_CONFIG) as mock_config:
+        mock_config.lookup_url = "https://lookup.example.com"
+        mock_config.token = "tok123"
+        mock_config.auth_url = "https://auth.example.com"
+        mock_config.verify_ssl = True
+        mock_config.disable_authentication = False
+        dialog._refresh_settings_dialog()
+
+    assert dialog.lookup_url_entry.get_text() == "https://lookup.example.com"
+    assert dialog.token_entry.get_text() == "tok123"
+    assert dialog.authenticator_url_entry.get_text() == "https://auth.example.com"
+    assert dialog.dtool_readme_template_fpath_file_chooser_button.get_filename() \
+        == str(readme_template)

--- a/test/test_simple_graph.py
+++ b/test/test_simple_graph.py
@@ -1,0 +1,138 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for the dependency-graph model (models.simple_graph).
+
+SimpleGraph is a plain vertex/edge container; GraphLayout runs a FIRE-based
+force optimization over it. Both are pure NumPy/SciPy with no GTK dependency.
+Layout positions are deterministic (grid initialization, no randomness), so the
+results are reproducible. Relevant to issue #182.
+"""
+import numpy as np
+import pytest
+
+from dtool_lookup_gui.models.simple_graph import SimpleGraph, GraphLayout
+
+
+def _make_graph(nb_vertices, edges=()):
+    g = SimpleGraph()
+    for i in range(nb_vertices):
+        g.add_vertex(label=f"v{i}")
+    for i, j in edges:
+        g.add_edge(i, j)
+    return g
+
+
+# ===========================================================================
+# SimpleGraph
+# ===========================================================================
+
+def test_empty_graph_has_no_vertices_or_edges():
+    g = SimpleGraph()
+    assert g.nb_vertices == 0
+    assert g.nb_edges == 0
+    assert g.vertex_properties == []
+    assert list(g.edges) == []
+
+
+def test_add_vertex_returns_index_and_stores_properties():
+    g = SimpleGraph()
+    assert g.add_vertex(name="a") == 0
+    assert g.add_vertex(name="b") == 1
+    assert g.nb_vertices == 2
+    assert g.vertex_properties == [{"name": "a"}, {"name": "b"}]
+
+
+def test_add_edge_records_endpoints():
+    g = _make_graph(3, [(0, 1), (1, 2)])
+    assert g.vertex1 == [0, 1]
+    assert g.vertex2 == [1, 2]
+    assert g.nb_edges == 2
+    assert list(g.edges) == [(0, 1), (1, 2)]
+
+
+@pytest.mark.parametrize("i,j", [(None, 0), (0, None), (-1, 0), (0, 3), (3, 0)])
+def test_add_edge_rejects_out_of_bounds(i, j):
+    g = _make_graph(3)
+    with pytest.raises(ValueError):
+        g.add_edge(i, j)
+
+
+def test_set_and_get_vertex_properties_round_trip():
+    g = _make_graph(3)
+    g.set_vertex_properties("color", ["red", "green", "blue"])
+    assert g.get_vertex_properties("color") == ["red", "green", "blue"]
+
+
+def test_set_vertex_properties_stops_at_shortest():
+    # zip() stops at the shorter sequence, so a short list updates a prefix.
+    g = _make_graph(3)
+    g.set_vertex_properties("rank", [1, 2])
+    assert g.get_vertex_properties("label") == ["v0", "v1", "v2"]
+    assert g.vertex_properties[0]["rank"] == 1
+    assert g.vertex_properties[1]["rank"] == 2
+    assert "rank" not in g.vertex_properties[2]
+
+
+# ===========================================================================
+# GraphLayout
+# ===========================================================================
+
+def test_layout_produces_one_position_per_vertex():
+    g = _make_graph(5, [(0, 1), (1, 2), (2, 3), (3, 4), (0, 4)])
+    layout = GraphLayout(g)
+    assert layout.graph is g
+    assert layout.positions.shape == (5, 2)
+    assert np.all(np.isfinite(layout.positions))
+
+
+def test_layout_single_vertex_is_stable():
+    # Exercises the nb_vertices <= 1 early-return branches in the force terms.
+    g = _make_graph(1)
+    layout = GraphLayout(g)
+    assert layout.positions.shape == (1, 2)
+    assert np.all(np.isfinite(layout.positions))
+
+
+def test_layout_without_edges_only_has_repulsion():
+    g = _make_graph(4)
+    layout = GraphLayout(g)
+    assert layout.positions.shape == (4, 2)
+    assert np.all(np.isfinite(layout.positions))
+
+
+def test_layout_iterate_keeps_positions_finite():
+    g = _make_graph(4, [(0, 1), (1, 2), (2, 3)])
+    layout = GraphLayout(g, init_iter=5)
+    before = layout.positions.copy()
+    layout.iterate()
+    assert layout.positions.shape == before.shape
+    assert np.all(np.isfinite(layout.positions))
+
+
+def test_layout_relaxes_connected_pair_towards_equilibrium():
+    # Two connected vertices should settle near the spring equilibrium distance.
+    g = _make_graph(2, [(0, 1)])
+    layout = GraphLayout(g, equilibrium_distance=2.0, init_iter=300)
+    distance = np.linalg.norm(layout.positions[0] - layout.positions[1])
+    assert distance == pytest.approx(2.0, abs=0.5)


### PR DESCRIPTION
## Summary

Extends unit-test coverage (part of #60, milestone 0.8.0) and, in the process, fixes two latent crashes that tests surfaced. Total coverage **71% → 77%**; 115 → 208 tests, all passing.

This branch is independent of #887 (both off `master`); they touch disjoint files and stack cleanly.

## Bug fixes

- **`GraphLayout` crashed on dependency graphs without edges** (likely #182). An empty edge list became a float NumPy array and raised `IndexError` when used to index positions — i.e. laying out a dataset with no dependencies crashed. Guarded the no-edge case. (`simple_graph.py`)
- **The `Gtk*EntryBufferHandler` log handlers were broken.** `Gtk.EntryBuffer.set_text()` was called with the wrong arity (GTK3 needs `text, n_chars`), and the message-shortening branch had a `'...' * list` typo. Both fixed; the handlers are now functional (they are not yet wired up in the app). (`utils/logging.py`)

## Test coverage added

| Module | Before | After |
|--------|-------:|------:|
| `models/simple_graph.py` | 65% | 100% |
| `models/search_state.py` | 85% | 100% |
| `utils/logging.py` | 77% | 100% |
| `utils/progressbar.py` | 30% | 100% |
| `utils/dependency_graph.py` | 83% | 100% |
| `views/settings_dialog.py` | 60% | 82% |
| `views/log_window.py` | 61% | 85% |
| **Total** | **71%** | **77%** |

New test modules: `test_simple_graph.py`, `test_search_state.py`, `test_logging.py`, `test_log_window.py`, `test_settings_dialog.py`, `test_progressbar.py`, plus extensions to `test_dependency_graph.py`. View handlers are exercised against the real dialogs/windows the app builds (via `running_app`), patching the lookup-server `Config`; no server is contacted. Modal file-chooser handlers are out of scope.

## Test plan

- `xvfb-run --auto-servernum pytest` — 208 passed locally (Python 3.12, Ubuntu 24.04).

Towards #60. The GraphLayout fix likely addresses #182 (worth confirming there are no other failure modes, e.g. very large graphs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)