### PR TITLE
DOC: refresh README, add CLAUDE.md, ignore /htmlcov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ __pycache__
 
 # pytest coverage data
 .coverage
+/htmlcov
 TRIAGE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`dtool-lookup-gui` is a GTK 3 / PyGObject desktop application (entry point `dtool-gui`)
+for browsing and managing [dtool](https://github.com/jic-dtool/dtool) datasets and for
+querying a [dtool-lookup-server](https://github.com/jic-dtool/dtool-lookup-server) and its
+mongo / dependency-graph plugins. It talks to servers through `dtool_lookup_api` and to
+local/remote (S3, SMB) storage through `dtoolcore`.
+
+## Setup, build, run
+
+The app cannot start until the GSettings schema is compiled. After `pip install -e .[test]`,
+run `glib-compile-schemas .` from **inside** `dtool_lookup_gui/` (produces
+`dtool_lookup_gui/gschemas.compiled`). Without it, launch fails with a
+`g-file-error-quark ... gschemas.compiled ... No such file` error. The custom build backend
+(`maintenance/custom_build_backend.py`) does this automatically for `build_wheel`/`build_sdist`,
+but an editable install does not — so do it by hand during development.
+
+- Run the app: `dtool-gui` (under Wayland use `GDK_BACKEND=x11 dtool-gui`).
+- Version comes from `setuptools_scm`, written to `dtool_lookup_gui/version.py`.
+- System deps: GTK 3 + GtkSourceView 4 (e.g. `gir1.2-gtksource-4`) plus the GObject-introspection
+  build packages — see `README.rst` and `.github/workflows/build-on-*.yml` for the exact
+  per-platform list.
+
+## Tests
+
+- Run all: `pytest` (config in `pyproject.toml`; collects coverage into an HTML report).
+- Single test: `pytest test/test_main_window_actions.py::test_do_search`.
+- Headless run needs an X server: `xvfb-run --auto-servernum pytest`. CI additionally
+  parallelizes with `pytest-xdist` (`-n`) under `tini` to reap zombie xdist workers.
+
+`test/conftest.py` is the heart of the test harness and worth reading before writing tests:
+
+- It sets `DBUS_SESSION_BUS_ADDRESS=/dev/null` and `GSETTINGS_BACKEND=memory` at import time
+  so each test process gets isolated settings and so multiple `Gio.Application` instances don't
+  collide on the exported D-Bus object path. Do not undo these.
+- `dtool_lookup_api` is fully mocked (patched at the `LookupClient` base classes) to return
+  fixture JSON from `test/data/`. Tests never reach a real server.
+- `asyncio` and the GTK main loop share one event loop via `gbulb` / `GLibEventLoopPolicy`
+  (a `CustomGLibEventLoopPolicy` in conftest). This is also how `main.run_gui` wires things.
+
+## Architecture
+
+The codebase follows an MVC-ish split, organized around **Gio.Actions** rather than direct
+signal callbacks.
+
+- `dtool_lookup_gui/main.py` — the `Gtk.Application` subclass: startup/activation lifecycle
+  (`do_startup`, `do_activate`, `do_command_line`), app-level actions (config import/export,
+  token renewal, logging), and custom GObject signals (`dtool-config-changed`, `token-renewed`,
+  `startup-done`, `activation-done`). `run_gui()` is the `dtool-gui` entry point.
+- `views/` — one `.py` + matching `.ui` (GtkBuilder XML) per window/dialog. `MainWindow`
+  (`views/main_window.py`) is the largest and hosts most window-level actions. UI classes use
+  the `@Gtk.Template(filename=...'.ui')` decorator.
+- `widgets/` — custom GTK widgets (list boxes, rows, popovers, graph rendering). These must be
+  imported in `main.py` purely to register their types with the GObject type system before the
+  `.ui` files referencing them are loaded — keep those imports.
+- `models/` — data layer wrapping `dtoolcore` / the lookup API: `DatasetModel`, the `BaseURI`
+  hierarchy (`LocalBaseURIModel`, `S3BaseURIModel`, `SMBBaseURIModel`, `LookupBaseURIModel`),
+  `SearchState`, `Settings`, and graph models.
+- `utils/` — async subprocess/multiprocessing helpers, copy manager, dependency-graph layout,
+  query parsing, logging.
+
+### Actions are the unit of behavior (read CONTRIBUTING.md)
+
+New behavior should be wrapped in atomic `Gio.SimpleAction`s, not ad-hoc signal handlers, so it
+can be triggered from the GUI, CLI, shortcuts, or tests. Conventions enforced in this repo:
+
+- Handler methods are named `do_<action>` (e.g. `do_search`) and attached to the app or the
+  window the action belongs to. Actions are created with `Gio.SimpleAction.new("name", param_type)`
+  and registered with `self.add_action(...)` (see the block in `MainWindow`).
+- Actions taking parameters use `GLib.Variant` parameter types (row index, URI string, etc.).
+- Write at least one unit test per action. The pattern is two tests: one calls `app.do_<action>(...)`
+  directly against mock data; the other activates it through the framework
+  (`app.activate_action('<action-name>')`) and asserts that mocked internals were invoked.
+
+## Conventions
+
+- Follow PEP 8 (line-length is the allowed exception).
+- Branch names are prefixed with creation date, e.g. `2023-04-06-pagination`.
+- Prefix commit messages with a type tag: `BUG`, `CI`, `DEP`, `DOC`, `ENH`, `MAINT`, `TST`, `WIP`.
+- Editing `.ui` files: the app uses custom widgets, so point Glade at `glade/catalog`
+  (Preferences → Extra Catalog & Template paths).
+- Packaging for releases is done with PyInstaller under `pyinstaller/` (per-platform `MANIFEST.*`
+  and spec files); CI lives in `.github/workflows/`.

--- a/README.rst
+++ b/README.rst
@@ -254,6 +254,13 @@ and perform an editable install with
 
    pip install -e .
 
+To also pull in the dependencies needed for running the test suite, install the
+``test`` extra instead:
+
+.. code:: bash
+
+   pip install -e .[test]
+
 Also run
 
 .. code:: bash
@@ -285,7 +292,16 @@ username and a password. To do this, click on the "Burger" symbol and select
 Pinned requirements
 ^^^^^^^^^^^^^^^^^^^
 
-``requirements.in`` contains unpinned dependencies. ``requirements.txt`` with pinned versions has been auto-generated with
+The runtime and test dependencies are declared, unpinned, in ``pyproject.toml``
+(under ``[project] dependencies`` and the ``test`` optional-dependency group). A
+plain ``pip install -e .[test]`` resolves them freshly and is what you want for
+development.
+
+Pinned dependency sets only exist for the packaged binary builds, one per target
+platform under ``pyinstaller/linux``, ``pyinstaller/macos`` and ``pyinstaller/win``.
+In each of those directories ``requirements.in`` lists the unpinned inputs and
+``requirements.txt`` holds the fully pinned versions, regenerated with
+`pip-tools <https://github.com/jazzband/pip-tools>`_:
 
 .. code:: bash
 
@@ -313,7 +329,32 @@ within Glade's preferences dialog.
 Running unit tests
 ^^^^^^^^^^^^^^^^^^
 
-Running the unit tests requires `pytest` and `pytest-asyncio`. Then, run all tests from repository root with `pytest`.
+The test dependencies (``pytest``, ``pytest-asyncio``, ``pytest-cov``,
+``pytest-xdist`` and the ``dtool-s3``/``dtool-smb`` plugins) come with the
+``test`` extra:
+
+.. code:: bash
+
+   pip install -e .[test]
+
+Make sure the GSettings schema has been compiled first (``glib-compile-schemas .``
+from within ``dtool_lookup_gui``, see Installation_ above) — otherwise the app
+cannot be imported and collection fails. Then run all tests from the repository
+root with
+
+.. code:: bash
+
+   pytest
+
+The tests drive a GTK application, so a display is required. On a headless
+machine, wrap the call in a virtual framebuffer:
+
+.. code:: bash
+
+   xvfb-run --auto-servernum pytest
+
+The suite mocks ``dtool_lookup_api`` entirely (see ``test/conftest.py``), so no
+running lookup server is needed.
 
 Funding
 -------


### PR DESCRIPTION
## Summary

Documentation refresh plus a small repo hygiene fix.

- **`DOC`** Refresh `README.rst`: correct the stale "Pinned requirements" section (the root `requirements.in`/`requirements.txt` no longer exist; pinned sets now live per-platform under `pyinstaller/{linux,macos,win}/`, while runtime/test deps are declared in `pyproject.toml`). Expand the install/test instructions (`pip install -e .[test]`, the mandatory `glib-compile-schemas .` step, headless `xvfb-run` runs, and that the suite mocks `dtool_lookup_api`).
- **`DOC`** Add `CLAUDE.md` describing the build/test workflow and the action-centric GTK architecture for future contributors / Claude Code.
- **`MAINT`** Add `/htmlcov` to `.gitignore` so the pytest coverage HTML report isn't reliant on coverage.py's auto-generated `htmlcov/.gitignore`.

Renders cleanly through docutils (only cosmetic Pygments-not-installed notes).

Relates to #247 (README not explicit enough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)