### PR TITLE
TST: cover dialogs, widgets and main-window handlers; fix base-URI row task typo

### DIFF
--- a/dtool_lookup_gui/widgets/base_uri_row.py
+++ b/dtool_lookup_gui/widgets/base_uri_row.py
@@ -109,4 +109,4 @@ class DtoolBaseURIRow(Gtk.ListBoxRow):
 
     @task.setter
     def task(self, task):
-        self._taks = task
+        self._task = task

--- a/test/test_configuration_dialogs.py
+++ b/test/test_configuration_dialogs.py
@@ -1,0 +1,141 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for the S3 and SMB base-URI configuration dialogs.
+
+These Gtk.Window dialogs are self-contained (their __init__ does not touch the
+application), so they are constructed directly. They read and write the dtool
+config through dtoolcore, which conftest.py isolates to a per-process temp file.
+"""
+from unittest.mock import MagicMock
+
+from dtoolcore.utils import get_config_value, write_config_value_to_file
+
+from dtool_lookup_gui.views.s3_configuration_dialog import S3ConfigurationDialog
+from dtool_lookup_gui.views.smb_configuration_dialog import SMBConfigurationDialog
+
+
+# ===========================================================================
+# S3ConfigurationDialog
+# ===========================================================================
+
+def test_s3_dialog_blank_when_no_bucket():
+    dialog = S3ConfigurationDialog()
+    assert dialog.bucket_entry.get_text() == ""
+    assert dialog.bucket_entry.get_sensitive() is True
+
+
+def test_s3_dialog_prefills_from_config_and_locks_bucket():
+    write_config_value_to_file("DTOOL_S3_ENDPOINT_prefill", "https://s3.example.com")
+    write_config_value_to_file("DTOOL_S3_ACCESS_KEY_ID_prefill", "AKIA")
+
+    dialog = S3ConfigurationDialog(bucket="prefill")
+
+    assert dialog.bucket_entry.get_text() == "prefill"
+    assert dialog.bucket_entry.get_sensitive() is False  # locked once known
+    assert dialog.endpoint_url_entry.get_text() == "https://s3.example.com"
+    assert dialog.access_key_entry.get_text() == "AKIA"
+
+
+def test_s3_dialog_apply_writes_config_and_calls_back():
+    apply = MagicMock()
+    dialog = S3ConfigurationDialog(apply=apply)
+    dialog.bucket_entry.set_text("applied")
+    dialog.endpoint_url_entry.set_text("https://endpoint")
+    dialog.access_key_entry.set_text("key-id")
+    dialog.secret_key_entry.set_text("secret")
+    dialog.prefix_entry.set_text("u/")
+
+    dialog.on_apply_clicked(None)
+
+    assert get_config_value("DTOOL_S3_ENDPOINT_applied") == "https://endpoint"
+    assert get_config_value("DTOOL_S3_ACCESS_KEY_ID_applied") == "key-id"
+    assert get_config_value("DTOOL_S3_SECRET_ACCESS_KEY_applied") == "secret"
+    assert get_config_value("DTOOL_S3_DATASET_PREFIX_applied") == "u/"
+    apply.assert_called_once()
+
+
+def test_s3_dialog_cancel_does_not_write_config():
+    dialog = S3ConfigurationDialog()
+    dialog.bucket_entry.set_text("cancelled")
+    dialog.endpoint_url_entry.set_text("https://nope")
+    dialog.on_cancel_clicked(None)
+    assert get_config_value("DTOOL_S3_ENDPOINT_cancelled") is None
+
+
+# ===========================================================================
+# SMBConfigurationDialog
+# ===========================================================================
+
+def test_smb_dialog_blank_when_no_name():
+    dialog = SMBConfigurationDialog()
+    assert dialog.name_entry.get_text() == ""
+    assert dialog.name_entry.get_sensitive() is True
+
+
+def test_smb_dialog_prefills_from_config_and_locks_name():
+    write_config_value_to_file("DTOOL_SMB_SERVER_NAME_prefillsmb", "fileserver")
+    write_config_value_to_file("DTOOL_SMB_SERVER_PORT_prefillsmb", 139)
+
+    dialog = SMBConfigurationDialog(name="prefillsmb")
+
+    assert dialog.name_entry.get_text() == "prefillsmb"
+    assert dialog.name_entry.get_sensitive() is False
+    assert dialog.server_name_entry.get_text() == "fileserver"
+    assert dialog.server_port_entry.get_text() == "139"
+
+
+def test_smb_dialog_default_port_when_unset():
+    # The port field falls back to 445 when no config value exists.
+    dialog = SMBConfigurationDialog(name="noport")
+    assert dialog.server_port_entry.get_text() == "445"
+
+
+def test_smb_dialog_apply_writes_config_and_calls_back():
+    apply = MagicMock()
+    dialog = SMBConfigurationDialog(apply=apply)
+    dialog.name_entry.set_text("smbapplied")
+    dialog.server_name_entry.set_text("server")
+    dialog.server_port_entry.set_text("445")
+    dialog.service_name_entry.set_text("share")
+    dialog.path_entry.set_text("/data")
+    dialog.domain_entry.set_text("WORKGROUP")
+    dialog.username_entry.set_text("alice")
+    dialog.password_entry.set_text("secret")
+
+    dialog.on_apply_clicked(None)
+
+    assert get_config_value("DTOOL_SMB_SERVER_NAME_smbapplied") == "server"
+    # The port is stored as an int.
+    assert get_config_value("DTOOL_SMB_SERVER_PORT_smbapplied") == 445
+    assert get_config_value("DTOOL_SMB_SERVICE_NAME_smbapplied") == "share"
+    assert get_config_value("DTOOL_SMB_USERNAME_smbapplied") == "alice"
+    apply.assert_called_once()
+
+
+def test_smb_dialog_cancel_does_not_write_config():
+    dialog = SMBConfigurationDialog()
+    dialog.name_entry.set_text("smbcancelled")
+    dialog.server_name_entry.set_text("nope")
+    dialog.on_cancel_clicked(None)
+    assert get_config_value("DTOOL_SMB_SERVER_NAME_smbcancelled") is None

--- a/test/test_dialogs.py
+++ b/test/test_dialogs.py
@@ -1,0 +1,143 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for the authentication, config-details and server-versions dialogs.
+
+These Gtk.Window dialogs are self-contained (their __init__ does not touch the
+application), so they are constructed directly. The config/versions dialogs
+fetch from the lookup server asynchronously; get_config / get_versions are
+mocked so no server is contacted.
+"""
+import asyncio
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dtool_lookup_gui.views.authentication_dialog import AuthenticationDialog
+from dtool_lookup_gui.views.config_details import ConfigDialog
+from dtool_lookup_gui.views.server_versions_dialog import ServerVersionsDialog
+
+
+# ===========================================================================
+# AuthenticationDialog
+# ===========================================================================
+
+def test_authentication_dialog_prefills_credentials():
+    dialog = AuthenticationDialog(username="bob", password="secret")
+    assert dialog.username_entry.get_text() == "bob"
+    assert dialog.password_entry.get_text() == "secret"
+
+
+def test_authentication_dialog_blank_by_default():
+    dialog = AuthenticationDialog()
+    assert dialog.username_entry.get_text() == ""
+    assert dialog.password_entry.get_text() == ""
+
+
+def test_authentication_dialog_apply_invokes_callback():
+    apply = MagicMock()
+    dialog = AuthenticationDialog(apply=apply)
+    dialog.username_entry.set_text("alice")
+    dialog.password_entry.set_text("pw")
+    dialog.on_apply_clicked(None)
+    apply.assert_called_once_with("alice", "pw")
+
+
+def test_authentication_dialog_cancel_does_not_invoke_callback():
+    apply = MagicMock()
+    dialog = AuthenticationDialog(apply=apply)
+    dialog.on_cancel_clicked(None)
+    apply.assert_not_called()
+
+
+# ===========================================================================
+# ConfigDialog
+# ===========================================================================
+
+def test_config_dialog_formats_server_config_as_json_lines():
+    dialog = ConfigDialog()
+    lines = dialog._format_server_config({"a": 1, "b": [1, 2]})
+    assert lines[0] == "{"
+    assert any('"a": 1' in line for line in lines)
+
+
+def test_config_dialog_delete_hides_window():
+    dialog = ConfigDialog()
+    assert dialog.on_config_delete(None, None) is True
+
+
+@pytest.mark.asyncio
+async def test_config_dialog_retrieve_populates_buffer():
+    dialog = ConfigDialog()
+    with patch("dtool_lookup_gui.views.config_details.get_config",
+               AsyncMock(return_value={"server": "x"})):
+        await dialog._retrieve_config()
+    buffer = dialog.config_text_view.get_buffer()
+    text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), False)
+    assert '"server"' in text
+
+
+@pytest.mark.asyncio
+async def test_config_dialog_show_schedules_retrieve():
+    dialog = ConfigDialog()
+    with patch("dtool_lookup_gui.views.config_details.get_config",
+               AsyncMock(return_value={"k": "v"})) as mock_get_config:
+        dialog.on_config_show(None)
+        await asyncio.sleep(0.05)  # let the scheduled task run
+    mock_get_config.assert_awaited()
+
+
+# ===========================================================================
+# ServerVersionsDialog
+# ===========================================================================
+
+def test_server_versions_dialog_formats_sorted_by_key_length():
+    dialog = ServerVersionsDialog()
+    formatted = dialog._format_server_versions({"dtool": "1.0", "x": "2"})
+    # shorter key name first
+    assert formatted == "x: <b>2</b>\ndtool: <b>1.0</b>"
+
+
+def test_server_versions_dialog_delete_hides_window():
+    dialog = ServerVersionsDialog()
+    assert dialog.on_delete(None, None) is True
+
+
+@pytest.mark.asyncio
+async def test_server_versions_dialog_retrieve_sets_label():
+    dialog = ServerVersionsDialog()
+    with patch("dtool_lookup_gui.views.server_versions_dialog.get_versions",
+               AsyncMock(return_value={"dtool": "1.0"})):
+        await dialog._retrieve_versions()
+    assert "dtool" in dialog.server_versions_label.get_text()
+
+
+@pytest.mark.asyncio
+async def test_server_versions_dialog_show_schedules_retrieve():
+    dialog = ServerVersionsDialog()
+    with patch("dtool_lookup_gui.views.server_versions_dialog.get_versions",
+               AsyncMock(return_value={"dtool": "1.0"})) as mock_get_versions:
+        dialog.on_show(None)
+        await asyncio.sleep(0.05)  # let the scheduled task run
+    mock_get_versions.assert_awaited()

--- a/test/test_graph_widget.py
+++ b/test/test_graph_widget.py
@@ -1,0 +1,144 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for the dependency-graph drawing widget (widgets.graph_widget).
+
+The shape helpers and the on_draw render path are exercised against an
+in-memory cairo surface (no realized window). The motion-notify and
+show-clicked handlers need a realized window / window action group and are out
+of scope here. Relevant to issue #182.
+"""
+import cairo
+import pytest
+
+from gi.repository import GLib
+
+from dtool_lookup_gui.widgets.graph_widget import (
+    DtoolGraphWidget,
+    circle,
+    square,
+    triangle,
+)
+from dtool_lookup_gui.models.simple_graph import SimpleGraph
+
+
+def _surface_context():
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
+    return cairo.Context(surface)
+
+
+def _graph_with_all_kinds():
+    graph = SimpleGraph()
+    graph.add_vertex(uuid="u-root", name="root", kind="root")
+    graph.add_vertex(uuid="u-dep", name="dep", kind="dependent")
+    graph.add_vertex(uuid="u-missing", name="missing", kind="does-not-exist")
+    graph.add_edge(1, 0)
+    graph.add_edge(2, 0)
+    return graph
+
+
+@pytest.fixture
+def widget():
+    w = DtoolGraphWidget()
+    yield w
+    # The graph setter installs a GLib timeout; remove it so it does not leak
+    # into the shared default main context used by other tests.
+    if w._timer is not None:
+        GLib.source_remove(w._timer)
+        w._timer = None
+
+
+# --- shape helpers ---------------------------------------------------------
+
+def test_shape_helpers_emit_paths():
+    context = _surface_context()
+    circle(context, 0.0, 0.0)
+    square(context, 1.0, 1.0)
+    triangle(context, 2.0, 2.0)
+    # A path has been built; copying it must not raise.
+    assert context.copy_path() is not None
+
+
+# --- properties ------------------------------------------------------------
+
+def test_search_by_uuid_round_trip(widget):
+    assert widget.search_by_uuid is None
+
+    def search(uuid):
+        return uuid
+
+    widget.search_by_uuid = search
+    assert widget.search_by_uuid is search
+
+
+def test_setting_graph_initializes_layout_and_state(widget):
+    graph = _graph_with_all_kinds()
+    widget.graph = graph
+    assert widget.graph is graph
+    assert widget._layout is not None
+    assert widget._layout.positions.shape == (3, 2)
+    # A per-vertex 'state' flag is initialized.
+    assert len(graph.get_vertex_properties("state")) == 3
+
+
+# --- drawing ---------------------------------------------------------------
+
+def test_on_draw_without_graph_is_noop(widget):
+    # No graph set yet -> early return, no error.
+    widget.on_draw(widget, _surface_context())
+
+
+def test_on_draw_renders_all_vertex_kinds_and_edges(widget):
+    widget.graph = _graph_with_all_kinds()
+    widget.on_draw(widget, _surface_context())
+
+
+def test_on_draw_renders_highlighted_vertex(widget):
+    graph = _graph_with_all_kinds()
+    widget.graph = graph
+    # Mark one vertex active to exercise the highlighted (stroked) branch.
+    graph.set_vertex_properties("state", [True, False, False])
+    widget.on_draw(widget, _surface_context())
+
+
+# --- misc handlers ---------------------------------------------------------
+
+def test_on_realize_is_noop(widget):
+    widget.on_realize(widget)
+
+
+def test_on_timeout_iterates_layout_and_reschedules(widget):
+    widget.graph = _graph_with_all_kinds()
+    # Returns True so the GLib timeout keeps firing.
+    assert widget.on_timeout(widget) is True
+
+
+def test_on_timeout_swallows_layout_errors(widget):
+    class BadLayout:
+        def iterate(self):
+            raise RuntimeError("boom")
+
+    widget._layout = BadLayout()
+    # Errors during a layout step are logged, not raised, and the timeout
+    # keeps rescheduling.
+    assert widget.on_timeout(widget) is True

--- a/test/test_main_window_handlers.py
+++ b/test/test_main_window_handlers.py
@@ -1,0 +1,294 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Tests for the MainWindow menu / selection / search signal handlers.
+
+These exercise the thin signal handlers against the real main window built
+during app activation (via running_app), mocking the dialogs and actions they
+delegate to. Assertions are grouped per handler family to limit the number of
+(slow) app activations. The modal file-chooser handlers (open-local-directory,
+add-items) use Gtk dialog.run() and are out of scope.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gi.repository import GLib, Gtk
+
+from dtool_lookup_gui.views.main_window import MainWindow
+
+_LAUNCH = "dtool_lookup_gui.views.main_window.launch_default_app_for_uri"
+
+
+def _main_window(app):
+    return [w for w in app.get_windows() if isinstance(w, MainWindow)][0]
+
+
+@pytest.mark.asyncio
+async def test_menu_handlers_show_their_windows(running_app):
+    main_window = _main_window(running_app)
+    handlers = [
+        ("on_settings_clicked", "settings_dialog"),
+        ("version_button_clicked", "server_versions_dialog"),
+        ("config_button_clicked", "config_details"),
+        ("on_logging_clicked", "log_window"),
+        ("on_about_clicked", "about_dialog"),
+    ]
+    for handler_name, dialog_attr in handlers:
+        with patch.object(getattr(main_window, dialog_attr), "show") as show:
+            getattr(main_window, handler_name)(None)
+        show.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_on_create_dataset_clicked_opens_name_dialog(running_app):
+    main_window = _main_window(running_app)
+    with patch("dtool_lookup_gui.views.main_window.DatasetNameDialog") as dialog_cls:
+        main_window.on_create_dataset_clicked(None)
+    dialog_cls.assert_called_once()
+    dialog_cls.return_value.show.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_selection_and_search_handlers_activate_actions(running_app):
+    main_window = _main_window(running_app)
+    with patch.object(main_window, "activate_action") as activate:
+        base_row = MagicMock()
+        base_row.get_index.return_value = 2
+        main_window.on_base_uri_selected(None, base_row)
+
+        dataset_row = MagicMock()
+        dataset_row.get_index.return_value = 5
+        main_window.on_dataset_selected(None, dataset_row)
+
+        main_window.search_entry.set_text("toluene")
+        main_window.on_search_activate(None)
+
+        # The None-row branches must be no-ops (no extra action activations).
+        main_window.on_base_uri_selected(None, None)
+        main_window.on_dataset_selected(None, None)
+
+    activated = [call.args[0] for call in activate.call_args_list]
+    assert activated == ["show-base-uri", "show-dataset", "search-select-show"]
+    # The search action carries the entry text.
+    search_call = next(c for c in activate.call_args_list
+                       if c.args[0] == "search-select-show")
+    assert search_call.args[1].get_string() == "toluene"
+
+
+@pytest.mark.asyncio
+async def test_refresh_dropdown_and_show_handlers(running_app):
+    main_window = _main_window(running_app)
+
+    # Refresh button delegates to the win-scoped refresh-view action.
+    with patch.object(main_window, "get_action_group") as get_group:
+        main_window.on_refresh_clicked(None)
+        get_group.return_value.activate_action.assert_called_once_with(
+            "refresh-view", None)
+
+    # Drop-down toggles the search popover: visible -> popdown.
+    with patch.object(main_window.search_popover, "get_visible", return_value=True), \
+            patch.object(main_window.search_popover, "popdown") as popdown:
+        main_window.on_search_drop_down_clicked(None)
+        popdown.assert_called_once()
+
+    # ... hidden -> popup_at the widget.
+    with patch.object(main_window.search_popover, "get_visible", return_value=False), \
+            patch.object(main_window.search_popover, "popup_at") as popup_at:
+        widget = object()
+        main_window.on_search_drop_down_clicked(widget)
+        popup_at.assert_called_once_with(widget)
+
+
+@pytest.mark.asyncio
+async def test_on_show_clicked_launches_only_with_selection(running_app):
+    main_window = _main_window(running_app)
+
+    # No dataset selected -> warn and do nothing.
+    with patch.object(main_window.dataset_list_box, "get_selected_row",
+                      return_value=None), \
+            patch(_LAUNCH) as launch:
+        main_window.on_show_clicked(None)
+        launch.assert_not_called()
+
+    # A dataset selected -> launch the default app for its URI.
+    row = MagicMock()
+    row.dataset = "file:///some/dataset"
+    with patch.object(main_window.dataset_list_box, "get_selected_row",
+                      return_value=row), \
+            patch(_LAUNCH) as launch:
+        main_window.on_show_clicked(None)
+        launch.assert_called_once_with("file:///some/dataset")
+
+
+@pytest.mark.asyncio
+async def test_pagination_buttons_activate_page_actions(running_app):
+    main_window = _main_window(running_app)
+    expected = [
+        ("on_first_page_button_clicked", "show-first-page"),
+        ("on_decrease_page_button_clicked", "show-previous-page"),
+        ("on_previous_page_button_clicked", "show-previous-page"),
+        ("on_current_page_button_clicked", "show-current-page"),
+        ("on_next_page_button_clicked", "show-next-page"),
+        ("on_increase_page_button_clicked", "show-next-page"),
+        ("on_last_page_button_clicked", "show-last-page"),
+    ]
+    with patch.object(main_window, "activate_action") as activate:
+        for handler_name, _ in expected:
+            getattr(main_window, handler_name)(None)
+    activated = [call.args[0] for call in activate.call_args_list]
+    assert activated == [action for _, action in expected]
+
+
+@pytest.mark.asyncio
+async def test_on_readme_buffer_changed_enables_save_button(running_app):
+    main_window = _main_window(running_app)
+    main_window.save_metadata_button.set_sensitive(False)
+    main_window.on_readme_buffer_changed(None)
+    assert main_window.save_metadata_button.get_sensitive() is True
+
+
+@pytest.mark.asyncio
+async def test_manifest_row_activated_shows_dialog_for_single_item(running_app):
+    main_window = _main_window(running_app)
+    with patch.object(main_window, "_get_selected_items",
+                      return_value=[("item.txt", "uuid-1")]), \
+            patch.object(main_window, "_show_get_item_dialog") as show_dialog:
+        main_window.on_manifest_row_activated(None, None, None)
+    show_dialog.assert_called_once_with("item.txt", "uuid-1")
+
+
+@pytest.mark.asyncio
+async def test_manifest_row_activated_rejects_multiple_items(running_app):
+    main_window = _main_window(running_app)
+    with patch.object(main_window, "_get_selected_items", return_value=[]):
+        with pytest.raises(ValueError):
+            main_window.on_manifest_row_activated(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_on_save_metadata_button_activates_save_action(running_app):
+    main_window = _main_window(running_app)
+    main_window.readme_source_view.get_buffer().set_text("desc: hello\n")
+    with patch.object(main_window, "activate_action") as activate:
+        main_window.on_save_metadata_button_clicked(None)
+    activate.assert_called_once()
+    assert activate.call_args.args[0] == "save-metadata"
+    assert "desc: hello" in activate.call_args.args[1].get_string()
+
+
+@pytest.mark.asyncio
+async def test_linting_errors_button_shows_dialog_only_with_problems(running_app):
+    main_window = _main_window(running_app)
+
+    main_window.linting_problems = ["problem A", "problem B"]
+    with patch.object(main_window.error_linting_dialog, "set_error_text") as set_text, \
+            patch.object(main_window.error_linting_dialog, "show") as show:
+        main_window.on_linting_errors_button_clicked(None)
+        set_text.assert_called_once()
+        show.assert_called_once()
+
+    main_window.linting_problems = []
+    with patch.object(main_window.error_linting_dialog, "show") as show:
+        main_window.on_linting_errors_button_clicked(None)
+        show.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_error_bar_handlers_hide_the_bar(running_app):
+    main_window = _main_window(running_app)
+    # Assert on the resulting call rather than an exact count: an info-bar log
+    # handler may also toggle set_revealed when records are emitted, so the count
+    # is not stable across the full suite (it depends on the active log level).
+    with patch.object(main_window.error_bar, "set_revealed") as set_revealed:
+        main_window.on_error_bar_close(None)
+        set_revealed.assert_called_with(False)
+
+        set_revealed.reset_mock()
+        main_window.on_error_bar_response(None, Gtk.ResponseType.CLOSE)
+        set_revealed.assert_called_with(False)
+
+        set_revealed.reset_mock()
+        main_window.on_error_bar_response(None, Gtk.ResponseType.OK)
+        set_revealed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sort_order_switch_sets_state_and_refreshes(running_app):
+    main_window = _main_window(running_app)
+    with patch.object(main_window, "activate_action") as activate:
+        main_window.on_sort_order_switch_state_set(None, True)
+        assert main_window.search_state.sort_order == [-1]
+        main_window.on_sort_order_switch_state_set(None, False)
+        assert main_window.search_state.sort_order == [1]
+    assert all(c.args[0] == "show-current-page" for c in activate.call_args_list)
+
+
+@pytest.mark.asyncio
+async def test_combo_box_handlers_update_search_state(running_app):
+    main_window = _main_window(running_app)
+    active = object()
+
+    per_page_widget = MagicMock()
+    per_page_widget.get_active_iter.return_value = active
+    per_page_widget.get_model.return_value = {active: [20, "20"]}
+
+    sort_field_widget = MagicMock()
+    sort_field_widget.get_active_iter.return_value = active
+    sort_field_widget.get_model.return_value = {active: ["name", "name"]}
+
+    with patch.object(main_window, "activate_action") as activate:
+        main_window.on_contents_per_page_combo_box_changed(per_page_widget)
+        main_window.on_sort_field_combo_box_changed(sort_field_widget)
+
+    assert main_window.search_state.page_size == 20
+    assert main_window.search_state.sort_fields == ["name"]
+    activated = [c.args[0] for c in activate.call_args_list]
+    assert activated == ["show-first-page", "show-current-page"]
+
+
+@pytest.mark.asyncio
+async def test_on_copy_clicked_activates_copy_dataset(running_app):
+    main_window = _main_window(running_app)
+
+    # No selection -> nothing happens.
+    with patch.object(main_window.dataset_list_box, "get_selected_row",
+                      return_value=None), \
+            patch.object(main_window, "activate_action") as activate:
+        main_window.on_copy_clicked(MagicMock())
+        activate.assert_not_called()
+
+    # With a selection -> copy-dataset action with (source, destination).
+    row = MagicMock()
+    row.dataset = "file:///src"
+    widget = MagicMock()
+    widget.destination = "s3://dest"
+    with patch.object(main_window.dataset_list_box, "get_selected_row",
+                      return_value=row), \
+            patch.object(main_window, "activate_action") as activate:
+        main_window.on_copy_clicked(widget)
+        activate.assert_called_once()
+        assert activate.call_args.args[0] == "copy-dataset"
+        source, destination = activate.call_args.args[1].unpack()
+        assert source == "file:///src"
+        assert destination == "s3://dest"

--- a/test/test_progress_chart.py
+++ b/test/test_progress_chart.py
@@ -1,0 +1,66 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for the DtoolProgressChart drawing-area widget.
+
+The widget draws a pie chart with cairo; on_draw is exercised against a real
+cairo context backed by an in-memory image surface, so no realized window is
+needed.
+"""
+import cairo
+
+from dtool_lookup_gui.widgets.progress_chart import DtoolProgressChart
+
+
+def test_fraction_initialised_from_kwarg():
+    assert DtoolProgressChart(fraction=0.25).fraction == 0.25
+
+
+def test_fraction_defaults_to_zero():
+    assert DtoolProgressChart().fraction == 0
+
+
+def test_set_fraction_updates_value():
+    chart = DtoolProgressChart()
+    chart.set_fraction(0.75)
+    assert chart.fraction == 0.75
+
+
+def test_set_text_does_not_raise():
+    # set_text only logs (the chart has no text), but must remain callable.
+    DtoolProgressChart().set_text("50%")
+
+
+def test_on_draw_renders_without_error():
+    chart = DtoolProgressChart(fraction=0.5)
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
+    context = cairo.Context(surface)
+    # Should execute the full cairo drawing path (scale, background, pie).
+    chart.on_draw(chart, context)
+
+
+def test_on_draw_handles_zero_and_full_fraction():
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 100, 100)
+    for fraction in (0.0, 1.0):
+        chart = DtoolProgressChart(fraction=fraction)
+        chart.on_draw(chart, cairo.Context(surface))

--- a/test/test_row_widgets.py
+++ b/test/test_row_widgets.py
@@ -1,0 +1,127 @@
+#
+# Copyright 2026 Johannes Laurin Hörmann
+#
+# ### MIT license
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Unit tests for the dataset and base-URI list-box row widgets.
+
+Both are plain Gtk.ListBoxRow subclasses that build their contents in __init__,
+so they are constructed directly with lightweight stand-in models.
+"""
+from dtool_lookup_gui.widgets.dataset_row import DtoolDatasetRow
+from dtool_lookup_gui.widgets.base_uri_row import DtoolBaseURIRow
+from dtool_lookup_gui.models.base_uris import LocalBaseURIModel, S3BaseURIModel
+
+
+class FakeDataset:
+    def __init__(self, is_frozen):
+        self.is_frozen = is_frozen
+        self.uuid = "1234-uuid"
+        self.name = "my_dataset"
+        self.creator = "alice"
+        self.date = "2023-05-11"
+        self.size_str = " 1.2 kB "
+
+    def freeze(self):
+        self.is_frozen = True
+
+
+# ===========================================================================
+# DtoolDatasetRow
+# ===========================================================================
+
+def test_dataset_row_frozen_shows_uuid_and_details():
+    row = DtoolDatasetRow(FakeDataset(is_frozen=True))
+    assert "1234-uuid" in row.uuid_label.get_label()
+    assert "*" not in row.uuid_label.get_label()
+    assert "my_dataset" in row.name_label.get_label()
+    assert "frozen at" in row.info_label.get_label()
+    assert "alice" in row.info_label.get_label()
+
+
+def test_dataset_row_proto_is_marked_and_not_yet_frozen():
+    row = DtoolDatasetRow(FakeDataset(is_frozen=False))
+    assert "* " in row.uuid_label.get_label()  # proto datasets are starred
+    assert "not yet frozen" in row.info_label.get_label()
+
+
+def test_dataset_row_exposes_dataset():
+    dataset = FakeDataset(is_frozen=True)
+    assert DtoolDatasetRow(dataset).dataset is dataset
+
+
+def test_dataset_row_freeze_refreshes_markup():
+    dataset = FakeDataset(is_frozen=False)
+    row = DtoolDatasetRow(dataset)
+    assert "* " in row.uuid_label.get_label()
+    row.freeze()
+    assert dataset.is_frozen is True
+    assert "* " not in row.uuid_label.get_label()
+
+
+def test_dataset_row_rebuild_clears_previous_contents():
+    row = DtoolDatasetRow(FakeDataset(is_frozen=True))
+    # Rebuilding must destroy the existing children before adding new ones.
+    row._build()
+    assert len(row.get_children()) == 1
+
+
+# ===========================================================================
+# DtoolBaseURIRow
+# ===========================================================================
+
+def test_base_uri_row_exposes_base_uri():
+    base_uri = LocalBaseURIModel("/data/store")
+    row = DtoolBaseURIRow(base_uri)
+    assert row.base_uri is base_uri
+
+
+def test_base_uri_row_builds_for_non_file_scheme_with_callbacks():
+    calls = []
+    row = DtoolBaseURIRow(
+        S3BaseURIModel("bucket"),
+        on_configure=lambda widget: calls.append("configure"),
+        on_remove=lambda widget: calls.append("remove"),
+        on_activate=lambda widget: calls.append("activate"),
+    )
+    assert row.base_uri.scheme == "s3"
+
+
+def test_base_uri_row_exposes_info_label():
+    row = DtoolBaseURIRow(LocalBaseURIModel("/data"))
+    assert row.info_label.get_text() == "---"
+
+
+def test_base_uri_row_spinner_start_stop_do_not_raise():
+    row = DtoolBaseURIRow(LocalBaseURIModel("/data"))
+    row.start_spinner()
+    row.stop_spinner()
+
+
+def test_base_uri_row_task_round_trip():
+    # Regression: the task setter previously wrote to a misspelled attribute,
+    # so the getter always returned None and the duplicate-task guard in the
+    # main window never held.
+    row = DtoolBaseURIRow(LocalBaseURIModel("/data"))
+    assert row.task is None
+    sentinel = object()
+    row.task = sentinel
+    assert row.task is sentinel


### PR DESCRIPTION
## Summary

Continues the test-coverage effort for #60 (milestone 0.8.0), focusing on the view/widget layer, and fixes a latent bug found along the way. Total project coverage rises to **86%**; 330 tests pass.

Branches off the current `master` (after #887 and #888 merged).

## Bug fix

- **`DtoolBaseURIRow.task` setter wrote to a misspelled attribute** (`self._taks` instead of `self._task`), so the getter always returned the initial `None`. In `main_window` the base-URI selection guard `if row.task is None` therefore never held, allowing a fresh select task to be spawned on every activation even while one was already running. Fixed and covered with a round-trip regression test. (`widgets/base_uri_row.py`)

## Test coverage added

| Module | Before | After |
|--------|-------:|------:|
| `views/s3_configuration_dialog.py` | 48% | 100% |
| `views/smb_configuration_dialog.py` | 45% | 100% |
| `views/authentication_dialog.py` | 57% | 100% |
| `views/config_details.py` | 74% | 100% |
| `views/server_versions_dialog.py` | 74% | 100% |
| `widgets/progress_chart.py` | 51% | 100% |
| `widgets/dataset_row.py` | 88% | 100% |
| `widgets/base_uri_row.py` | 91% | 100% |
| `widgets/graph_widget.py` | 33% | 80% |
| `views/main_window.py` | 81% | 86% |

New test modules: `test_configuration_dialogs.py`, `test_dialogs.py`, `test_progress_chart.py`, `test_row_widgets.py`, `test_graph_widget.py`, `test_main_window_handlers.py`.

### Approach
- The self-contained dialogs/widgets are constructed directly (no app), so these tests are fast; the lookup-server `get_config`/`get_versions` calls are mocked.
- Cairo drawing paths (progress chart, dependency-graph widget) are exercised against an in-memory image surface — no realized window.
- The `main_window` signal handlers are exercised against the real window built during activation (`running_app`), mocking the dialogs/actions they delegate to.
- Out of scope: modal file-chooser / message-dialog handlers (`dialog.run()`), the graph widget's motion-notify / show-clicked (need a realized window or window action group), and async data-flow methods.

## Test plan

- `xvfb-run --auto-servernum pytest` — 330 passed locally (Python 3.12, Ubuntu 24.04).

Towards #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)