### PR TITLE
CI: fix published test-coverage report showing 0%

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,8 +53,18 @@ jobs:
             libgtksourceview-4-0
 
       - name: Install app
+        # Editable install so coverage measures the same dtool_lookup_gui copy
+        # the tests import. A non-editable install drops the package into
+        # site-packages; tests then execute that copy while coverage reports the
+        # in-tree copy, yielding a misleading 0% report on the published pages.
         run: |
-            pip install .[test]
+            pip install -e .[test]
+
+      # Editable installs skip the custom build backend that compiles the GLib
+      # schema, so compile it explicitly (otherwise importing the app fails).
+      - name: Compile GLib schemas
+        run: glib-compile-schemas .
+        working-directory: dtool_lookup_gui
 
         # run in virtual X server, see https://github.com/pygobject/pygobject-travis-ci-docker-examples
       - name: Test with pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,10 @@ jobs:
           pip list
 
       - name: Install app
+        # Editable install so coverage measures the same dtool_lookup_gui copy
+        # the tests import (a non-editable install reports 0% -- see coverage.yml).
         run: |
-          pip install .[test]
+          pip install -e .[test]
 
       # dtool-cli 0.7.1 uses pkg_resources which was removed in Python 3.12.
       # Patch the installed cli.py with an importlib.metadata shim.


### PR DESCRIPTION
## Problem

The coverage report published to https://livmats.github.io/dtool-lookup-gui/ shows **0%** (3843 statements, all "missing") even though the test suite covers ~86%.

## Root cause

`coverage.yml` installs the app **non-editably** (`pip install .[test]`), so `dtool_lookup_gui` lands in `site-packages`. The CI log confirms the tests execute that copy:

```
.../site-packages/dtool_lookup_gui/views/main_window.py
```

…but `coverage.py` measures and reports the **in-tree** copy (`dtool_lookup_gui/views/main_window.py`). Two copies of the same files → the measured (in-tree) copy is never executed → every statement reads as unhit → 0%.

(The same latent issue exists in `test.yml`, but its coverage output isn't published, so it goes unnoticed; the tests themselves pass regardless.)

## Fix

- Install **editable** (`pip install -e .[test]`) so a single `dtool_lookup_gui` copy is resolved in the main process and every `pytest-xdist` worker; coverage then measures exactly what runs.
- Add an explicit `glib-compile-schemas` step — editable installs bypass the custom build backend that normally compiles the GLib schema, which the app needs at import time.

## Verification

Locally (editable venv), `pytest -n 2 --cov` reports correct per-module coverage (e.g. `search_state.py` and `simple_graph.py` at 100%), whereas the non-editable CI run reports 0% for the same code. xdist is not the cause — editable + `-n` measures correctly.

After merge, the `coverage.yml` run on `master` will republish the report with real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)